### PR TITLE
feat[#51013]: Extend page header with parent link, context bar actions and responsiveness

### DIFF
--- a/.changeset/giant-carrots-explain.md
+++ b/.changeset/giant-carrots-explain.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': minor
+---
+
+Extend page header with parent link, context bar actions and responsiveness

--- a/app/components/primer/open_project/page_header.html.erb
+++ b/app/components/primer/open_project/page_header.html.erb
@@ -1,9 +1,17 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
-  <%= breadcrumbs %>
-  <div class="PageHeader-titleBar">
+  <% if parent_link || breadcrumbs || context_bar_actions %>
+    <div class="PageHeader-contextArea">
+      <%= parent_link %>
+      <%= breadcrumbs %>
+      <%= context_bar_actions %>
+    </div>
+  <% end %>
+
+  <div class="PageHeader-titleArea">
     <%= back_button %>
     <%= title %>
     <%= actions %>
   </div>
+
   <%= description %>
 <% end %>

--- a/app/components/primer/open_project/page_header.html.erb
+++ b/app/components/primer/open_project/page_header.html.erb
@@ -1,13 +1,13 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <% if parent_link || breadcrumbs || context_bar_actions %>
-    <div class="PageHeader-contextArea">
+    <div class="PageHeader-contextBar">
       <%= parent_link %>
       <%= breadcrumbs %>
       <%= context_bar_actions %>
     </div>
   <% end %>
 
-  <div class="PageHeader-titleArea">
+  <div class="PageHeader-titleBar">
     <%= back_button %>
     <%= title %>
     <%= actions %>

--- a/app/components/primer/open_project/page_header.pcss
+++ b/app/components/primer/open_project/page_header.pcss
@@ -15,7 +15,7 @@
 .PageHeader-contextBar {
   display: flex;
   flex-flow: row;
-  justify-content: flex-start;
+  justify-content: flex-end;
   align-items: center;
 }
 
@@ -47,6 +47,7 @@
 .PageHeader-actions {
   margin: 0 0 0 var(--base-size-4);
   justify-content: flex-end;
+  display: flex;
 
   & + .PageHeader-description {
     margin-top: var(--base-size-4);
@@ -65,6 +66,11 @@
   margin-right: var(--base-size-4);
 }
 
-.PageHeader-parentLink, .PageHeader-contextBarActions {
+.PageHeader-parentLink {
+  flex: 1 1 auto;
   margin-bottom: var(--base-size-4);
+}
+
+.PageHeader-contextBarActions {
+  margin: 0 0 0 var(--base-size-4);
 }

--- a/app/components/primer/open_project/page_header.pcss
+++ b/app/components/primer/open_project/page_header.pcss
@@ -17,7 +17,6 @@
   flex-flow: row;
   justify-content: flex-start;
   align-items: center;
-  margin-bottom: var(--base-size-4);
 }
 
 .PageHeader-titleArea {
@@ -46,7 +45,7 @@
 
 /* Add 1 or 2 buttons to the right of the heading */
 .PageHeader-actions {
-  margin: var(--base-size-4) 0 var(--base-size-4) var(--base-size-4);
+  margin: 0 0 0 var(--base-size-4);
   justify-content: flex-end;
 
   & + .PageHeader-description {
@@ -57,10 +56,15 @@
 .PageHeader-breadcrumbs {
   display: block;
   width: 100%;
-  margin-bottom: var(--base-size-4);
+  margin-bottom: var(--base-size-8);
+  padding-bottom: var(--base-size-4);
 }
 
 .PageHeader-backButton {
   margin-top: 2px; /* to center align with label */
   margin-right: var(--base-size-4);
+}
+
+.PageHeader-parentLink, .PageHeader-contextBarActions {
+  margin-bottom: var(--base-size-4);
 }

--- a/app/components/primer/open_project/page_header.pcss
+++ b/app/components/primer/open_project/page_header.pcss
@@ -12,14 +12,14 @@
   }
 }
 
-.PageHeader-contextArea {
+.PageHeader-contextBar {
   display: flex;
   flex-flow: row;
   justify-content: flex-start;
   align-items: center;
 }
 
-.PageHeader-titleArea {
+.PageHeader-titleBar {
   display: flex;
   flex-flow: row;
   justify-content: flex-end;

--- a/app/components/primer/open_project/page_header.pcss
+++ b/app/components/primer/open_project/page_header.pcss
@@ -12,7 +12,15 @@
   }
 }
 
-.PageHeader-titleBar {
+.PageHeader-contextArea {
+  display: flex;
+  flex-flow: row;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: var(--base-size-4);
+}
+
+.PageHeader-titleArea {
   display: flex;
   flex-flow: row;
   justify-content: flex-end;
@@ -49,7 +57,7 @@
 .PageHeader-breadcrumbs {
   display: block;
   width: 100%;
-  margin-bottom: var(--base-size-8);
+  margin-bottom: var(--base-size-4);
 }
 
 .PageHeader-backButton {

--- a/app/components/primer/open_project/page_header.rb
+++ b/app/components/primer/open_project/page_header.rb
@@ -27,6 +27,10 @@ module Primer
         "triangle-left"
       ].freeze
 
+      DEFAULT_BACK_BUTTON_DISPLAY = [:none, :flex].freeze
+      DEFAULT_BREADCRUMBS_DISPLAY = [:none, :flex].freeze
+      DEFAULT_PARENT_LINK_DISPLAY = [:block, :none].freeze
+
       status :open_project
 
       # The title of the page header
@@ -64,6 +68,17 @@ module Primer
         Primer::BaseComponent.new(**system_arguments)
       }
 
+      # Context Bar Actions
+      #
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      renders_one :context_bar_actions, lambda { |**system_arguments|
+        deny_tag_argument(**system_arguments)
+        system_arguments[:tag] = :div
+        system_arguments[:classes] = class_names(system_arguments[:classes], "PageHeader-contextBarActions")
+
+        Primer::BaseComponent.new(**system_arguments)
+      }
+
       # Optional back button prepend the title
       #
       # @param size [Symbol] <%= one_of(Primer::OpenProject::PageHeader::BACK_BUTTON_SIZE_OPTIONS) %>
@@ -80,8 +95,23 @@ module Primer
         system_arguments[:size] = fetch_or_fallback(BACK_BUTTON_SIZE_OPTIONS, size, DEFAULT_BACK_BUTTON_SIZE)
         system_arguments[:icon] = fetch_or_fallback(BACK_BUTTON_ICON_OPTIONS, icon, DEFAULT_BACK_BUTTON_ICON)
         system_arguments[:classes] = class_names(system_arguments[:classes], "PageHeader-backButton")
+        system_arguments[:display] ||= DEFAULT_BACK_BUTTON_DISPLAY
 
         Primer::Beta::IconButton.new(**system_arguments)
+      }
+
+      # Optional parent link in the context area
+      #
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      renders_one :parent_link, lambda { |icon: DEFAULT_BACK_BUTTON_ICON, **system_arguments, &block|
+        deny_tag_argument(**system_arguments)
+        system_arguments[:icon] = fetch_or_fallback(BACK_BUTTON_ICON_OPTIONS, icon, DEFAULT_BACK_BUTTON_ICON)
+        system_arguments[:classes] = class_names(system_arguments[:classes], "PageHeader-parentLink")
+        system_arguments[:display] ||= DEFAULT_PARENT_LINK_DISPLAY
+
+        render(Primer::Beta::Link.new(scheme: :primary, muted: true, **system_arguments)) do
+          render(Primer::Beta::Octicon.new(icon: "arrow-left", "aria-label": "aria_label", mr: 2)) + content_tag(:span, &block)
+        end
       }
 
       # Optional breadcrumbs above the title row
@@ -90,6 +120,8 @@ module Primer
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :breadcrumbs, lambda { |items, **system_arguments|
         system_arguments[:classes] = class_names(system_arguments[:classes], "PageHeader-breadcrumbs")
+        system_arguments[:display] ||= DEFAULT_BREADCRUMBS_DISPLAY
+
         render(Primer::Beta::Breadcrumbs.new(**system_arguments)) do |breadcrumbs|
           items.each do |item|
             item = anchor_string_to_object(item) if anchor_tag_string?(item)

--- a/app/components/primer/open_project/page_header.rb
+++ b/app/components/primer/open_project/page_header.rb
@@ -30,6 +30,7 @@ module Primer
       DEFAULT_BACK_BUTTON_DISPLAY = [:none, :flex].freeze
       DEFAULT_BREADCRUMBS_DISPLAY = [:none, :flex].freeze
       DEFAULT_PARENT_LINK_DISPLAY = [:block, :none].freeze
+      DEFAULT_CONTEXT_BAR_ACTIONS_DISPLAY = [:block, :none].freeze
 
       status :open_project
 
@@ -75,6 +76,7 @@ module Primer
         deny_tag_argument(**system_arguments)
         system_arguments[:tag] = :div
         system_arguments[:classes] = class_names(system_arguments[:classes], "PageHeader-contextBarActions")
+        system_arguments[:display] ||= DEFAULT_CONTEXT_BAR_ACTIONS_DISPLAY
 
         Primer::BaseComponent.new(**system_arguments)
       }

--- a/app/components/primer/open_project/page_header.rb
+++ b/app/components/primer/open_project/page_header.rb
@@ -70,6 +70,7 @@ module Primer
       }
 
       # Context Bar Actions
+      # By default shown on narrow screens. Can be overridden with system_argument: display
       #
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :context_bar_actions, lambda { |**system_arguments|
@@ -82,6 +83,7 @@ module Primer
       }
 
       # Optional back button prepend the title
+      # By default shown on wider screens. Can be overridden with system_argument: display
       #
       # @param size [Symbol] <%= one_of(Primer::OpenProject::PageHeader::BACK_BUTTON_SIZE_OPTIONS) %>
       # @param icon [String] <%= one_of(Primer::OpenProject::PageHeader::BACK_BUTTON_ICON_OPTIONS) %>
@@ -103,6 +105,7 @@ module Primer
       }
 
       # Optional parent link in the context area
+      # By default shown on narrow screens. Can be overridden with system_argument: display
       #
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :parent_link, lambda { |icon: DEFAULT_BACK_BUTTON_ICON, **system_arguments, &block|
@@ -117,6 +120,7 @@ module Primer
       }
 
       # Optional breadcrumbs above the title row
+      # By default shown on wider screens. Can be overridden with system_argument: display
       #
       # @param items [Array<String, Hash>] Items is an array of strings, hash {href, text} or an anchor tag string
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>

--- a/previews/primer/open_project/page_header_preview.rb
+++ b/previews/primer/open_project/page_header_preview.rb
@@ -21,13 +21,15 @@ module Primer
       # @param with_back_button [Boolean]
       # @param back_button_size [Symbol] select [small, medium, large]
       # @param with_breadcrumbs [Boolean]
+      # @param parent_link [Boolean]
       def playground(
         variant: :medium,
         title: "Hello",
         description: "Last updated 5 minutes ago by XYZ.",
         with_back_button: false,
         back_button_size: :medium,
-        with_breadcrumbs: false
+        with_breadcrumbs: false,
+        parent_link: false
       )
         breadcrumb_items = [{ href: "/foo", text: "Foo" }, { href: "/bar", text: "Bar" }, "Baz"]
 
@@ -36,6 +38,7 @@ module Primer
           header.with_description { description }
           header.with_back_button(href: "#", size: back_button_size, 'aria-label': "Back") if with_back_button
           header.with_breadcrumbs(breadcrumb_items) if with_breadcrumbs
+          header.with_parent_link(href: "#") { "Parent link" } if parent_link
         end
       end
 
@@ -73,6 +76,14 @@ module Primer
         render(Primer::OpenProject::PageHeader.new) do |header|
           header.with_title { "A title" }
           header.with_breadcrumbs(breadcrumb_items)
+        end
+      end
+
+      # @label With parent link
+      def parent_link
+        render(Primer::OpenProject::PageHeader.new) do |header|
+          header.with_title { "A title" }
+          header.with_parent_link(href: "test") { "Parent link" }
         end
       end
     end

--- a/previews/primer/open_project/page_header_preview.rb
+++ b/previews/primer/open_project/page_header_preview.rb
@@ -55,7 +55,11 @@ module Primer
         render_with_template(locals: {})
       end
 
-      # @label With back button
+      # @label With back button (on wide)
+      # **Back button** is only shown on **wider than narrow screens** by default.
+      # If you want to override that behaviour please use the system_argument: **display**
+      # e.g. **component.with\_breadcrumbs(display: [:block, :block])**
+      #
       # @param href [String] text
       # @param size [Symbol] select [small, medium, large]
       # @param icon [String] select ["arrow-left", "chevron-left", "triangle-left"]
@@ -66,7 +70,11 @@ module Primer
         end
       end
 
-      # @label With breadcrumbs
+      # @label With breadcrumbs (on wide)
+      # **Breadcrumbs** are only shown on **wider than narrow screens** by default.
+      # If you want to override that behaviour please use the system_argument: **display**
+      # e.g. **component.with\_breadcrumbs(display: [:block, :block])**
+      #
       def breadcrumbs
         breadcrumb_items = [
           { href: "/foo", text: "Foo" },
@@ -79,12 +87,25 @@ module Primer
         end
       end
 
-      # @label With parent link
+      # @label With parent link (on narrow)
+      # **Parent link** is only shown on **narrow screens** by default.
+      # If you want to override that behaviour please use the system_argument: **display**
+      # e.g. **component.with\_parent\_link(display: [:block, :block])**
+      #
       def parent_link
         render(Primer::OpenProject::PageHeader.new) do |header|
           header.with_title { "A title" }
           header.with_parent_link(href: "test") { "Parent link" }
         end
+      end
+
+      # @label With context bar actions (on narrow)
+      # **Context bar actions** are only shown on **narrow screens** by default.
+      # If you want to override that behaviour please use the system_argument: **display**
+      # e.g. **component.with\_context\_bar\_actions(display: [:block, :block])**
+      #
+      def context_bar_actions
+        render_with_template(locals: {})
       end
     end
   end

--- a/previews/primer/open_project/page_header_preview.rb
+++ b/previews/primer/open_project/page_header_preview.rb
@@ -21,7 +21,9 @@ module Primer
       # @param with_back_button [Boolean]
       # @param back_button_size [Symbol] select [small, medium, large]
       # @param with_breadcrumbs [Boolean]
-      # @param parent_link [Boolean]
+      # @param with_actions [Boolean]
+      # @param with_context_bar_actions [Boolean]
+      # @param with_parent_link [Boolean]
       def playground(
         variant: :medium,
         title: "Hello",
@@ -29,17 +31,22 @@ module Primer
         with_back_button: false,
         back_button_size: :medium,
         with_breadcrumbs: false,
-        parent_link: false
+        with_actions: false,
+        with_context_bar_actions: false,
+        with_parent_link: false
       )
         breadcrumb_items = [{ href: "/foo", text: "Foo" }, { href: "/bar", text: "Bar" }, "Baz"]
 
-        render(Primer::OpenProject::PageHeader.new) do |header|
-          header.with_title(variant: variant) { title }
-          header.with_description { description }
-          header.with_back_button(href: "#", size: back_button_size, 'aria-label': "Back") if with_back_button
-          header.with_breadcrumbs(breadcrumb_items) if with_breadcrumbs
-          header.with_parent_link(href: "#") { "Parent link" } if parent_link
-        end
+        render_with_template(locals: { variant: variant,
+                                       title: title,
+                                       description: description,
+                                       with_back_button: with_back_button,
+                                       back_button_size: back_button_size,
+                                       with_breadcrumbs: with_breadcrumbs,
+                                       with_parent_link: with_parent_link,
+                                       with_actions: with_actions,
+                                       with_context_bar_actions: with_context_bar_actions,
+                                       breadcrumb_items: breadcrumb_items })
       end
 
       # @label Large

--- a/previews/primer/open_project/page_header_preview/context_bar_actions.html.erb
+++ b/previews/primer/open_project/page_header_preview/context_bar_actions.html.erb
@@ -1,0 +1,25 @@
+<%= render(Primer::OpenProject::PageHeader.new) do |component| %>
+  <% component.with_title(tag: :h1) do %>
+    A title
+  <% end %>
+  <% component.with_description do %>
+    A description with actions
+  <% end %>
+  <% component.with_parent_link(href: "#") do %>
+    Parent link
+  <% end %>
+  <% component.with_context_bar_actions do %>
+    <%= render(Primer::Alpha::ActionMenu.new) do |component| %>
+      <% component.with_show_button { "Menu" } %>
+      <% component.with_item(label: "Item", tag: :button, value: "") %>
+      <% component.with_item(
+           label: "Show dialog",
+           tag: :button,
+           content_arguments: { "data-show-dialog-id": "my-dialog" },
+           value: "",
+           scheme: :danger
+         ) %>
+    <% end %>
+  <% end %>
+<% end %>
+

--- a/previews/primer/open_project/page_header_preview/playground.html.erb
+++ b/previews/primer/open_project/page_header_preview/playground.html.erb
@@ -1,0 +1,32 @@
+<%= render Primer::OpenProject::PageHeader.new do |header| %>
+  <%= header.with_title(variant: variant) { title } %>
+  <%= header.with_description { description } %>
+  <%= header.with_back_button(href: "#", size: back_button_size, 'aria-label': "Back") if with_back_button %>
+  <%= header.with_breadcrumbs(breadcrumb_items) if with_breadcrumbs %>
+  <%= header.with_parent_link(href: "#") { "Parent link" } if with_parent_link %>
+  <% if with_actions %>
+    <% header.with_actions do %>
+      <%= render(Primer::Alpha::ActionMenu.new) do |component| %>
+        <% component.with_show_button { "Menu" } %>
+        <% component.with_item(label: "Item", tag: :button, value: "") %>
+        <% component.with_item(
+             label: "Show dialog",
+             tag: :button,
+             content_arguments: { "data-show-dialog-id": "my-dialog" },
+             value: "",
+             scheme: :danger
+           ) %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <% if with_context_bar_actions %>
+    <% header.with_context_bar_actions do %>
+      <%= render(Primer::Beta::IconButton.new(
+        scheme: :default,
+        size: :small,
+        icon: "pencil",
+        "aria-label": "aria_label"
+      )) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/test/components/primer/open_project/page_header_test.rb
+++ b/test/components/primer/open_project/page_header_test.rb
@@ -82,4 +82,26 @@ class PrimerOpenProjectPageHeaderTest < Minitest::Test
     assert_selector("nav[aria-label='Breadcrumb'].PageHeader-breadcrumbs .breadcrumb-item a[href='/foo/bar']")
     assert_selector("nav[aria-label='Breadcrumb'].PageHeader-breadcrumbs .breadcrumb-item a[href='#']")
   end
+
+  def test_renders_parent_link
+    render_inline(Primer::OpenProject::PageHeader.new) do |header|
+      header.with_title { "Hello" }
+      header.with_parent_link(href: "test") { "Parent link" }
+    end
+
+    assert_text("Hello")
+    assert_selector(".PageHeader-title")
+    assert_selector(".PageHeader-parentLink")
+  end
+
+  def test_renders_context_bar_actions
+    render_inline(Primer::OpenProject::PageHeader.new) do |header|
+      header.with_title { "Hello" }
+      header.with_context_bar_actions { "An context bar action" }
+    end
+
+    assert_text("Hello")
+    assert_selector(".PageHeader-title")
+    assert_selector(".PageHeader-contextBarActions")
+  end
 end


### PR DESCRIPTION
- Relevant WP [OP#51013](https://community.openproject.org/wp/51013)


### What are you trying to accomplish?
This PR extends page header with parent link, context bar actions and responsiveness.


### Screenshots
<img width="433" alt="Screenshot with parent link and context action bar" src="https://github.com/opf/primer_view_components/assets/1113942/84933d17-d67a-41f5-86ab-0f14465ed71f">

<img width="968" alt="Screenshot with back button and breadcrumbs" src="https://github.com/opf/primer_view_components/assets/1113942/2a464193-8442-49ee-9964-9bbef3a2dbcb">


### Integration
no



#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.



### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
