### PR TITLE
Changed width to max-width for text field style

### DIFF
--- a/.changeset/textfield-max-width.md
+++ b/.changeset/textfield-max-width.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+TextField style now uses max-width

--- a/app/components/primer/alpha/text_field.pcss
+++ b/app/components/primer/alpha/text_field.pcss
@@ -228,27 +228,27 @@
 /* widths */
 @define-mixin FormControl-input-width {
   &.FormControl-input-width--auto {
-    width: auto;
+    max-width: auto;
   }
 
   &.FormControl-input-width--small {
-    width: min(256px, 100vw - 2rem);
+    max-width: min(256px, 100vw - 2rem);
   }
 
   &.FormControl-input-width--medium {
-    width: min(320px, 100vw - 2rem);
+    max-width: min(320px, 100vw - 2rem);
   }
 
   &.FormControl-input-width--large {
-    width: min(480px, 100vw - 2rem);
+    max-width: min(480px, 100vw - 2rem);
   }
 
   &.FormControl-input-width--xlarge {
-    width: min(640px, 100vw - 2rem);
+    max-width: min(640px, 100vw - 2rem);
   }
 
   &.FormControl-input-width--xxlarge {
-    width: min(960px, 100vw - 2rem);
+    max-width: min(960px, 100vw - 2rem);
   }
 }
 


### PR DESCRIPTION
This PR changes the `width` CSS attribute of text input wraps to `max-width` to support a wider experience for smaller mobile views.