### PR TITLE
Allow setting an `id` attribute on the BorderBox's `ul` element

### DIFF
--- a/.changeset/strong-lamps-yawn.md
+++ b/.changeset/strong-lamps-yawn.md
@@ -1,0 +1,7 @@
+---
+"@openproject/primer-view-components": patch
+---
+
+Allow setting an `id` attribute on the BorderBox's `ul` element
+
+<!-- Changed components: Primer::Beta::BorderBox --> 

--- a/app/components/primer/beta/border_box.rb
+++ b/app/components/primer/beta/border_box.rb
@@ -73,6 +73,8 @@ module Primer
       # @param padding [Symbol] <%= one_of(Primer::Beta::BorderBox::PADDING_MAPPINGS.keys) %>
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(padding: DEFAULT_PADDING, **system_arguments)
+        list_id = system_arguments.delete(:list_id)
+
         @system_arguments = deny_tag_argument(**system_arguments)
         @system_arguments[:tag] = :div
         @system_arguments[:classes] = class_names(
@@ -83,6 +85,7 @@ module Primer
 
         @system_arguments[:system_arguments_denylist] = { [:p, :pt, :pb, :pr, :pl] => PADDING_SUGGESTION }
         @list_arguments = { tag: :ul }
+        @list_arguments[:id] = list_id if list_id
       end
 
       def render?

--- a/previews/primer/beta/border_box_preview.rb
+++ b/previews/primer/beta/border_box_preview.rb
@@ -8,8 +8,9 @@ module Primer
       #
       # @param padding [Symbol] select [default, condensed, spacious]
       # @param scheme [Symbol] select [default, neutral, info, warning]
-      def playground(padding: :default, scheme: :default)
-        render(Primer::Beta::BorderBox.new(padding: padding)) do |component|
+      # @param list_id [String] text
+      def playground(padding: :default, scheme: :default, list_id: nil)
+        render(Primer::Beta::BorderBox.new(padding: padding, list_id: list_id)) do |component|
           component.with_header { "Header" }
           component.with_body { "Body" }
           component.with_row(scheme: scheme) { "#{scheme.to_s.capitalize} row one" }

--- a/test/components/beta/border_box_test.rb
+++ b/test/components/beta/border_box_test.rb
@@ -60,6 +60,15 @@ class PrimerBetaBorderBoxTest < Minitest::Test
     assert_selector("li.Box-row", count: 3)
   end
 
+  def test_renders_the_list_element_with_an_id_if_provided
+    render_inline(Primer::Beta::BorderBox.new(list_id: "an-id")) do |component|
+      component.with_row { "First" }
+    end
+
+    assert_selector("ul#an-id", count: 1)
+    assert_selector("li.Box-row", count: 1)
+  end
+
   def test_renders_condensed
     render_inline(Primer::Beta::BorderBox.new(padding: :condensed)) do |component|
       component.with_body { "Body" }


### PR DESCRIPTION
### What are you trying to accomplish?
In order to perform turbo stream append and prepend actions on a `BorderBox` component, we need a way to specify a target via an `id` (or some unique CSS selector). We can't guarantee there is a unique selector for the specific BorderBox's `ul` element we want to append to without an id.

This commit allows providing the `id` that will be rendered in the `BorderBox`'s ul element via the `list_id` system argument.

A system argument has been added to the "Playground" preview for the `BorderBox`.

### Screenshots
#### Before
<img width="998" alt="Before picture" src="https://github.com/opf/primer_view_components/assets/61627014/dd974203-692a-47b8-b0dc-972ca0af9ac5">

#### After
<img width="1000" alt="After picture" src="https://github.com/opf/primer_view_components/assets/61627014/7b53ae0e-055e-4153-ba36-edc4f28c081a">


### Integration
No

#### List the issues that this change affects.

https://community.openproject.org/wp/51277

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
