### PR TITLE
Remove invalid CSS rule for `input_width: :auto`

### DIFF
--- a/.changeset/metal-hounds-behave.md
+++ b/.changeset/metal-hounds-behave.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Fix invalid CSS rule for `input_width: :auto`

--- a/app/components/primer/alpha/text_field.pcss
+++ b/app/components/primer/alpha/text_field.pcss
@@ -228,7 +228,7 @@
 /* widths */
 @define-mixin FormControl-input-width {
   &.FormControl-input-width--auto {
-    max-width: auto;
+    width: auto;
   }
 
   &.FormControl-input-width--small {


### PR DESCRIPTION
`auto` is not a valid argument for `max-width`, so I changed it to `width`.