### PR TITLE
Bug/51376 - Add `Primer::OpenProject::InputGroup` captions

### DIFF
--- a/app/components/primer/open_project/input_group.html.erb
+++ b/app/components/primer/open_project/input_group.html.erb
@@ -1,4 +1,10 @@
 <%= render(Primer::BaseComponent.new(**@system_arguments)) do %>
-  <%= text_input %>
-  <%= trailing_action %>
+  <%= render(Primer::Beta::Text.new(tag: :div, display: :flex, align_items: :flex_end)) do %>
+    <%= text_input %>
+    <%= trailing_action %>
+  <% end %>
+
+  <%= render(Primer::Beta::Text.new(tag: :div, display: :flex, direction: :column)) do %>
+    <%= caption %>
+  <% end %>
 <% end %>

--- a/app/components/primer/open_project/input_group.rb
+++ b/app/components/primer/open_project/input_group.rb
@@ -47,6 +47,7 @@ module Primer
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :text_input, lambda { |readonly: true, **system_arguments|
         deny_single_argument(:input_width, "Set the `input_width` on the `InputGroup`", **system_arguments)
+        deny_single_argument(:caption, "Set the `caption` on the `InputGroup`", **system_arguments)
         system_arguments[:input_width] = @system_arguments[:input_width]
 
         system_arguments[:classes] = class_names(
@@ -65,12 +66,19 @@ module Primer
         Primer::Alpha::TextField.new(**system_arguments)
       }
 
+      renders_one :caption, lambda { |**system_arguments|
+        system_arguments[:classes] = class_names(
+          system_arguments[:classes],
+          "FormControl-caption"
+        )
+
+        Primer::Beta::Text.new(**system_arguments)
+      }
+
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(**system_arguments)
         @system_arguments = system_arguments
         @system_arguments[:tag] = :div
-        @system_arguments[:display] = :flex
-        @system_arguments[:align_items] = :flex_end
 
         @system_arguments[:input_width] = fetch_or_fallback(
           Primer::OpenProject::InputGroup::INPUT_WIDTH_OPTIONS,

--- a/previews/primer/open_project/input_group_preview.rb
+++ b/previews/primer/open_project/input_group_preview.rb
@@ -58,6 +58,15 @@ module Primer
           menu.with_trailing_action_clipboard_copy_button(id: "button-4", value: "Some value", aria: { label: "Copy some text" })
         end
       end
+
+      # @label With a caption
+      def with_caption
+        render(Primer::OpenProject::InputGroup.new) do |menu|
+          menu.with_text_input(name: 'a name', label: 'My input group', value: "Copyable value")
+          menu.with_trailing_action_clipboard_copy_button(id: "button", value: "Copyable value", aria: { label: "Copy some text" })
+          menu.with_caption { "Some caption" }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

https://community.openproject.org/wp/51376

Support first party captions on the `Primer::OpenProject::InputGroup` component- providing the caption via the `text_input` breaks the traling_action layout, hence the system argument is also denied.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
