### PR TITLE
Make custom width preview easier to discover

### DIFF
--- a/previews/primer/forms_preview/custom_width_fields_form.html.erb
+++ b/previews/primer/forms_preview/custom_width_fields_form.html.erb
@@ -1,3 +1,5 @@
+<!-- Look at the "Assets" tab for the definition of the `CustomWidthFieldsForm` -->
+
 <%= primer_form_with(url: "/foo") do |f| %>
   <%= render(CustomWidthFieldsForm.new(f)) %>
 <% end %>


### PR DESCRIPTION
The FormComponent is shown in the Assets tab, but that is not easy to discover, so I added a comment

