### PR TITLE
Single action buttons should shrink on mobile in Primer::OpenProject::PageHeader

### DIFF
--- a/.changeset/few-teachers-pull.md
+++ b/.changeset/few-teachers-pull.md
@@ -1,0 +1,5 @@
+---
+"@openproject/primer-view-components": patch
+---
+
+Show single actions of Primer::OpenProject::PageHeader in a smaller variant on mobile

--- a/app/components/primer/open_project/page_header.html.erb
+++ b/app/components/primer/open_project/page_header.html.erb
@@ -8,6 +8,8 @@
           <% menu.with_show_button(icon: :"kebab-horizontal", size: :small, "aria-label": @mobile_menu_label) %>
           <% @desktop_menu_block.call(menu) unless @desktop_menu_block.nil? %>
         <% end %>
+      <% elsif actions.length == 1 && @mobile_action.present? %>
+        <%= render(@mobile_action) { |el| @mobile_action_block.call(el) unless @mobile_action_block.nil?} %>
       <% end %>
     </div>
   <% end %>

--- a/app/components/primer/open_project/page_header.pcss
+++ b/app/components/primer/open_project/page_header.pcss
@@ -47,16 +47,6 @@
   align-items: center;
 }
 
-.PageHeader--singleAction .PageHeader-action {
-  @media (max-width: 543.98px) {
-    position: absolute;
-    top: 10px;
-
-    /* Normally, the actions are hidden on mobile, except for this special case of a single action */
-    display: flex !important;
-  }
-}
-
 .PageHeader-breadcrumbs {
   display: block;
   width: 100%;

--- a/app/components/primer/open_project/page_header_element.ts
+++ b/app/components/primer/open_project/page_header_element.ts
@@ -1,22 +1,7 @@
-import {controller, targets} from '@github/catalyst'
+import {controller} from '@github/catalyst'
 
 @controller
 class PageHeaderElement extends HTMLElement {
-  @targets actionItems: HTMLElement[]
-
-  connectedCallback() {
-    for (const item of this.actionItems) {
-      /*
-      If there is only one action to be shown, we show that instead of the mobile action menu. However, the buttons should be the smaller button variant.
-      Unfortunately, the `size` attribute does not support responsive attributes and the .pcss syntax does not support inheritance between classes.
-      So we have to add the class manually here.
-      */
-      if (window.innerWidth <= 544) {
-        item.classList.add('Button--small')
-      }
-    }
-  }
-
   menuItemClick(event: Event) {
     const currentTarget = event.currentTarget as HTMLButtonElement
 

--- a/app/components/primer/open_project/zen_mode_button.html.erb
+++ b/app/components/primer/open_project/zen_mode_button.html.erb
@@ -4,6 +4,7 @@
             scheme: :default,
             id: "zenModeButton",
             icon: ZEN_MODE_BUTTON_ICON,
+            size: @button_size,
             aria: { label: ZEN_MODE_BUTTON_LABEL },
             data: { target: "zen-mode-button.button", action: "click:zen-mode-button#performAction" }
           )

--- a/app/components/primer/open_project/zen_mode_button.rb
+++ b/app/components/primer/open_project/zen_mode_button.rb
@@ -20,6 +20,8 @@ module Primer
           @system_arguments[:classes],
           "ZenModeButton"
         )
+
+        @button_size = @system_arguments[:size] || Primer::Beta::Button::DEFAULT_SIZE
       end
     end
   end

--- a/previews/primer/open_project/page_header_preview.rb
+++ b/previews/primer/open_project/page_header_preview.rb
@@ -120,6 +120,21 @@ module Primer
         end
       end
 
+
+      # @label With a single action
+      # The single action will not be transformed into a menu on mobile, but remains in a smaller variant
+      def single_action
+        render(Primer::OpenProject::PageHeader.new) do |component|
+          component.with_title { "Great news" }
+          component.with_breadcrumbs([{ href: "/foo", text: "Foo" }, { href: "/bar", text: "Bar" }, "Baz"])
+
+          component.with_action_button(mobile_icon: "plus", mobile_label: "Meeting", scheme: :primary) do |button|
+            button.with_leading_visual_icon(icon: "plus")
+            "Meeting"
+          end
+        end
+      end
+
       # @label With leading action (on wide)
       # **Leading action** is only shown on **wide screens** by default.
       # If you want to override that behaviour please use the system_argument: **display**

--- a/static/classes.json
+++ b/static/classes.json
@@ -429,9 +429,6 @@
   "PageHeader": [
     "Primer::OpenProject::PageHeader"
   ],
-  "PageHeader--singleAction": [
-    "Primer::OpenProject::PageHeader"
-  ],
   "PageHeader-actions": [
     "Primer::OpenProject::PageHeader"
   ],

--- a/static/constants.json
+++ b/static/constants.json
@@ -1463,7 +1463,7 @@
       "h5",
       "h6"
     ],
-    "MORE_MENU_DISPLAY": [
+    "MOBILE_ACTIONS_DISPLAY": [
       "flex",
       "none"
     ],

--- a/test/components/primer/open_project/page_header_test.rb
+++ b/test/components/primer/open_project/page_header_test.rb
@@ -154,7 +154,7 @@ class PrimerOpenProjectPageHeaderTest < Minitest::Test
     assert_selector(".PageHeader-title")
     assert_text("An action")
     assert_selector(".PageHeader-actions")
-    assert_selector(".PageHeader--singleAction")
+    assert_selector(".PageHeader-contextBar .Button--small.d-flex.d-sm-none")
   end
 
   def test_renders_leading_action

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -182,9 +182,6 @@ class ComponentSpecificSelectorsTest < Minitest::Test
       ".InputGroup-input-width--large",
       ".InputGroup-input-width--xlarge",
       ".InputGroup-input-width--xxlarge",
-    ],
-    Primer::OpenProject::PageHeader => [
-      ".PageHeader--singleAction .PageHeader-action",
     ]
   }.freeze
 


### PR DESCRIPTION
If a PageHeader has only a single action, it should not collapse into a menu on mobile, but stay visible in the context area with smaller size. Before, this was done via a catalyst controller. The `connectedCallback` of the controller however sometimes fires too early, resultig in the button not shrinking correctly. 

So instead, a mobile alternative is preserved for each button. That alternative has the correct `size` attrbute already set and is only rendered in the context bar when there is a single action.

see: https://community.openproject.org/projects/openproject/work_packages/54357#activity-7