### PR TITLE
Segment control can be used as weekly button, so 7 is better than 5.

### DIFF
--- a/app/components/primer/alpha/segmented_control.rb
+++ b/app/components/primer/alpha/segmented_control.rb
@@ -60,8 +60,8 @@ module Primer
       end
 
       def render?
-        valid_items_count = items.count <= (@hide_labels ? 6 : 5) && items.count >= 2
-        raise ArgumentError, "A segmented control should have 2–5 choices with text labels, or up to 6 icon-only buttons." if !valid_items_count && !Rails.env.production?
+        valid_items_count = items.count <= (@hide_labels ? 8 : 7) && items.count >= 2
+        raise ArgumentError, "A segmented control should have 2–7 choices with text labels, or up to 8 icon-only buttons." if !valid_items_count && !Rails.env.production?
 
         valid_items_count
       end

--- a/test/components/primer/alpha/segmented_control_test.rb
+++ b/test/components/primer/alpha/segmented_control_test.rb
@@ -80,10 +80,12 @@ module Primer
             component.with_item(label: "Item 4") { "Item 4" }
             component.with_item(label: "Item 5") { "Item 5" }
             component.with_item(label: "Item 6") { "Item 6" }
+            component.with_item(label: "Item 7") { "Item 7" }
+            component.with_item(label: "Item 8") { "Item 8" }
           end
         end
 
-        assert_equal(error.message, "A segmented control should have 2–5 choices with text labels, or up to 6 icon-only buttons.")
+        assert_equal(error.message, "A segmented control should have 2–7 choices with text labels, or up to 8 icon-only buttons.")
       end
 
       def test_doesnt_render_with_too_many_icon_items
@@ -96,10 +98,12 @@ module Primer
             component.with_item(icon: :zap, label: "Item 5") { "Item 5" }
             component.with_item(icon: :zap, label: "Item 6") { "Item 6" }
             component.with_item(icon: :zap, label: "Item 7") { "Item 7" }
+            component.with_item(icon: :zap, label: "Item 8") { "Item 8" }
+            component.with_item(icon: :zap, label: "Item 9") { "Item 9" }
           end
         end
 
-        assert_equal(error.message, "A segmented control should have 2–5 choices with text labels, or up to 6 icon-only buttons.")
+        assert_equal(error.message, "A segmented control should have 2–7 choices with text labels, or up to 8 icon-only buttons.")
       end
 
       def test_raises_if_no_aria_label_is_provided


### PR DESCRIPTION
### What are you trying to accomplish?
Allow 1 week filling form can using SegmentControl

### Screenshots

<img width="1199" alt="image" src="https://github.com/opf/primer_view_components/assets/1131536/3a8ad7a8-67e9-4137-920c-4f7d6c9be558">

#### Risk Assessment
- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
It's very directly, IMHO.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
