### PR TITLE
[#55190] Extend primer component PageHeader to support Tabs

### DIFF
--- a/.changeset/happy-numbers-attend.md
+++ b/.changeset/happy-numbers-attend.md
@@ -1,0 +1,5 @@
+---
+"@openproject/primer-view-components": minor
+---
+
+Adds a TabNav slot to Primer::OpenProject::PageHeader

--- a/app/components/primer/open_project/page_header.html.erb
+++ b/app/components/primer/open_project/page_header.html.erb
@@ -27,4 +27,5 @@
   </div>
 
   <%= description %>
+  <%= tab_nav %>
 <% end %>

--- a/app/components/primer/open_project/page_header.pcss
+++ b/app/components/primer/open_project/page_header.pcss
@@ -8,6 +8,11 @@
   flex-flow: column;
 }
 
+.PageHeader--noBorder {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
 .PageHeader-contextBar {
   display: flex;
   flex-flow: row;
@@ -59,4 +64,9 @@
 
 .PageHeader-parentLink {
   flex: 1 1 auto;
+}
+
+.PageHeader-tabNav {
+  margin-top: var(--stack-gap-normal);
+  margin-bottom: 0;
 }

--- a/app/components/primer/open_project/page_header.rb
+++ b/app/components/primer/open_project/page_header.rb
@@ -205,6 +205,19 @@ module Primer
         end
       }
 
+      # Optional tabs nav at the bottom of the page header
+      #
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      renders_one :tab_nav, lambda { |**system_arguments, &block|
+        @system_arguments[:classes] = class_names(@system_arguments[:classes], "PageHeader--noBorder")
+
+        system_arguments = deny_tag_argument(**system_arguments)
+        system_arguments[:tag] = :div
+        system_arguments[:classes] = class_names(system_arguments[:classes], "PageHeader-tabNav")
+
+        Primer::Alpha::TabNav.new(**system_arguments, &block)
+      }
+
       # @param mobile_menu_label [String] The tooltip label of the mobile menu
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(mobile_menu_label: I18n.t("label_more"), **system_arguments)

--- a/previews/primer/open_project/page_header_preview.rb
+++ b/previews/primer/open_project/page_header_preview.rb
@@ -23,12 +23,14 @@ module Primer
       # @param description [String] text
       # @param with_leading_action [Symbol] octicon
       # @param with_actions [Boolean]
+      # @param with_tab_nav [Boolean]
       def playground(
         variant: :medium,
         title: "Hello",
         description: "Last updated 5 minutes ago by XYZ.",
         with_leading_action: :"none",
-        with_actions: true
+        with_actions: true,
+        with_tab_nav: false
       )
         breadcrumb_items = [{ href: "/foo", text: "Foo" }, { href: "/bar", text: "Bar" }, "Baz"]
 
@@ -37,7 +39,8 @@ module Primer
                                        description: description,
                                        with_leading_action: with_leading_action,
                                        with_actions: with_actions,
-                                       breadcrumb_items: breadcrumb_items })
+                                       breadcrumb_items: breadcrumb_items,
+                                       with_tab_nav: with_tab_nav})
       end
 
       # @label Large title
@@ -165,6 +168,23 @@ module Primer
         render(Primer::OpenProject::PageHeader.new) do |header|
           header.with_title { "A title" }
           header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: :normal)
+        end
+      end
+
+      # @label With tab nav
+      #
+      def tab_nav
+        render(Primer::OpenProject::PageHeader.new) do |header|
+          header.with_title { "Hello" }
+          header.with_breadcrumbs([{ href: "/foo", text: "Foo" }, { href: "/bar", text: "Bar" }, "Baz"])
+          header.with_description { "Last updated 5 minutes ago by XYZ." }
+          header.with_tab_nav(label: "label") do |nav|
+            Array.new(3) do |i|
+              nav.with_tab(selected: i.zero? , href: "#") do |tab|
+                tab.with_text { "Tab #{i + 1}" }
+              end
+            end
+          end
         end
       end
     end

--- a/previews/primer/open_project/page_header_preview/playground.html.erb
+++ b/previews/primer/open_project/page_header_preview/playground.html.erb
@@ -14,4 +14,11 @@
       <% end %>
     <% end %>
   <% end %>
+  <% if with_tab_nav %>
+    <% header.with_tab_nav(label: "label") do |nav|%>
+      <% nav.with_tab(selected: true, href: "#") { "Tab 1" } %>
+      <% nav.with_tab(href: "#") { "Tab 2" } %>
+      <% nav.with_tab(href: "#") { "Tab 3" } %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/static/classes.json
+++ b/static/classes.json
@@ -429,6 +429,9 @@
   "PageHeader": [
     "Primer::OpenProject::PageHeader"
   ],
+  "PageHeader--noBorder": [
+    "Primer::OpenProject::PageHeader"
+  ],
   "PageHeader-actions": [
     "Primer::OpenProject::PageHeader"
   ],
@@ -445,6 +448,9 @@
     "Primer::OpenProject::PageHeader"
   ],
   "PageHeader-parentLink": [
+    "Primer::OpenProject::PageHeader"
+  ],
+  "PageHeader-tabNav": [
     "Primer::OpenProject::PageHeader"
   ],
   "PageHeader-title": [

--- a/test/components/primer/open_project/page_header_test.rb
+++ b/test/components/primer/open_project/page_header_test.rb
@@ -215,6 +215,24 @@ class PrimerOpenProjectPageHeaderTest < Minitest::Test
     assert_selector("nav[aria-label='Breadcrumb'].PageHeader-breadcrumbs .breadcrumb-item:not(.text-bold) a[href='#']")
   end
 
+  def test_renders_tab_nav
+    render_inline(Primer::OpenProject::PageHeader.new) do |header|
+      header.with_title { "Hello" }
+      header.with_breadcrumbs(breadcrumb_elements)
+      header.with_tab_nav(label: "label") do |nav|
+        Array.new(3) do |i|
+          nav.with_tab(selected: i.zero? , href: "#") do |tab|
+            tab.with_text { "Tab #{i + 1}" }
+          end
+        end
+      end
+    end
+
+    assert_selector(".PageHeader--noBorder")
+    assert_selector(".PageHeader-tabNav")
+    assert_selector(".PageHeader-tabNav .tabnav-tab")
+  end
+
   private
 
   def breadcrumb_elements


### PR DESCRIPTION
https://community.openproject.org/work_packages/55190

### What are you trying to accomplish?
- Adds TabNav slot to PageHeader
- Removes PageHeader bottom border when TabNave is rendered

### Screenshots
<img width="899" alt="PageHeader with TabNav slot" src="https://github.com/opf/primer_view_components/assets/1113942/a93ea8eb-dc5d-4470-b8c7-35a64809be3c">

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
