### PR TITLE
[#55190] Fix Tab Nav vertical spacing in Page Header

### DIFF
--- a/.changeset/cool-lions-jog.md
+++ b/.changeset/cool-lions-jog.md
@@ -1,0 +1,5 @@
+---
+"@openproject/primer-view-components": patch
+---
+
+Fix Tab Nav vertical spacing in Page Header

--- a/app/components/primer/open_project/page_header.pcss
+++ b/app/components/primer/open_project/page_header.pcss
@@ -66,7 +66,7 @@
   flex: 1 1 auto;
 }
 
-.PageHeader-tabNav {
+.PageHeader-tabNav, .PageHeader-tabNav.tabnav {
   margin-top: var(--stack-gap-normal);
   margin-bottom: 0;
 }

--- a/app/components/primer/open_project/page_header.pcss
+++ b/app/components/primer/open_project/page_header.pcss
@@ -8,9 +8,10 @@
   flex-flow: column;
 }
 
-.PageHeader--noBorder {
+.PageHeader--withTabNav {
   border-bottom: none;
   padding-bottom: 0;
+  margin-bottom: 0;
 }
 
 .PageHeader-contextBar {
@@ -46,6 +47,10 @@
   flex: 1 100%;
 }
 
+.PageHeader--withTabNav .PageHeader-description {
+  margin-bottom: var(--space-xlarge);
+}
+
 .PageHeader-actions {
   justify-content: flex-end;
   display: flex;
@@ -64,9 +69,4 @@
 
 .PageHeader-parentLink {
   flex: 1 1 auto;
-}
-
-.PageHeader-tabNav, .PageHeader-tabNav.tabnav {
-  margin-top: var(--stack-gap-normal);
-  margin-bottom: 0;
 }

--- a/app/components/primer/open_project/page_header.rb
+++ b/app/components/primer/open_project/page_header.rb
@@ -209,7 +209,7 @@ module Primer
       #
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :tab_nav, lambda { |**system_arguments, &block|
-        @system_arguments[:classes] = class_names(@system_arguments[:classes], "PageHeader--noBorder")
+        @system_arguments[:classes] = class_names(@system_arguments[:classes], "PageHeader--withTabNav")
 
         system_arguments = deny_tag_argument(**system_arguments)
         system_arguments[:tag] = :div

--- a/static/classes.json
+++ b/static/classes.json
@@ -429,7 +429,7 @@
   "PageHeader": [
     "Primer::OpenProject::PageHeader"
   ],
-  "PageHeader--noBorder": [
+  "PageHeader--withTabNav": [
     "Primer::OpenProject::PageHeader"
   ],
   "PageHeader-actions": [
@@ -448,9 +448,6 @@
     "Primer::OpenProject::PageHeader"
   ],
   "PageHeader-parentLink": [
-    "Primer::OpenProject::PageHeader"
-  ],
-  "PageHeader-tabNav": [
     "Primer::OpenProject::PageHeader"
   ],
   "PageHeader-title": [

--- a/test/components/primer/open_project/page_header_test.rb
+++ b/test/components/primer/open_project/page_header_test.rb
@@ -228,7 +228,7 @@ class PrimerOpenProjectPageHeaderTest < Minitest::Test
       end
     end
 
-    assert_selector(".PageHeader--noBorder")
+    assert_selector(".PageHeader.PageHeader--withTabNav")
     assert_selector(".PageHeader-tabNav")
     assert_selector(".PageHeader-tabNav .tabnav-tab")
   end


### PR DESCRIPTION
https://community.openproject.org/work_packages/55190

### What are you trying to accomplish?
 Fix Tab Nav vertical spacing in Page Header when deployed

### Screenshots
Before:
![image](https://github.com/opf/primer_view_components/assets/1113942/375dbf56-acd6-4cf1-a482-f62a0a2ec6f4)

After:
<img width="1728" alt="Screenshot 2024-05-28 at 19 13 26" src="https://github.com/opf/primer_view_components/assets/1113942/3d1a9347-7084-4c2b-b3e6-b4f4ef24a0d9">

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
