### PR TITLE
Fix spacings for OpenProject::SubHeader

### DIFF
--- a/.changeset/fifty-roses-bake.md
+++ b/.changeset/fifty-roses-bake.md
@@ -1,0 +1,5 @@
+---
+"@openproject/primer-view-components": patch
+---
+
+Fix spacings in OpenProject::SubHeader when some elements are not present

--- a/app/components/primer/open_project/sub_header.html.erb
+++ b/app/components/primer/open_project/sub_header.html.erb
@@ -5,7 +5,7 @@
       <%= render @mobile_filter_cancel do
         I18n.t("button_cancel")
       end if @mobile_filter_cancel.present? %>
-    <% end if @filter_container.present? %>
+    <% end if filter_input.present? %>
     <%= render @mobile_filter_trigger if @mobile_filter_trigger.present? %>
     <%= filter_button %>
   </div>

--- a/app/components/primer/open_project/sub_header.pcss
+++ b/app/components/primer/open_project/sub_header.pcss
@@ -4,8 +4,8 @@
     display: grid;
     grid-template-areas: "left middle right" "bottom bottom bottom";
     grid-template-columns: auto 1fr auto;
-    row-gap: 16px;
     align-items: center;
+    margin-bottom: 16px;
 
     /* When the filter input is expanded in mobile, we switch to a flex layout */
     flex-wrap: wrap;
@@ -25,7 +25,6 @@
 
 .SubHeader-bottomPane {
     grid-area: bottom;
-    margin-bottom: 16px;
 }
 
 .SubHeader-leftPane {

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -108,16 +108,15 @@ module Primer
         system_arguments[:font_weight] ||= :bold
 
         Primer::Beta::Text.new(**system_arguments)
-
       }
 
       # A slot for a generic component which will be shown in a second row below the rest, spanning the whole width
       renders_one :bottom_pane_component, lambda { |**system_arguments|
         deny_tag_argument(**system_arguments)
         system_arguments[:tag] = :div
+        system_arguments[:mt] ||= 3
 
         Primer::BaseComponent.new(**system_arguments)
-
       }
 
 


### PR DESCRIPTION
Fix spacings for SubHeader when filter_input or bottom pane are not present


