### PR TITLE
Allow PageHeader to receive SegmentedControl action

### DIFF
--- a/.changeset/many-pumpkins-rest.md
+++ b/.changeset/many-pumpkins-rest.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': minor
+---
+
+Allow segmented control action in page header

--- a/app/components/primer/open_project/page_header.html.erb
+++ b/app/components/primer/open_project/page_header.html.erb
@@ -3,6 +3,9 @@
     <div class="PageHeader-contextBar">
       <%= @parent_link %>
       <%= breadcrumbs %>
+      <% if @mobile_segmented_control %>
+        <%= render(@mobile_segmented_control, &@mobile_segmented_control_block) %>
+      <% end %>
       <% if render_mobile_menu? %>
         <%= render(@mobile_action_menu) do |menu| %>
           <% menu.with_show_button(icon: :"kebab-horizontal", size: :small, "aria-label": @mobile_menu_label) %>

--- a/app/components/primer/open_project/page_header.rb
+++ b/app/components/primer/open_project/page_header.rb
@@ -141,6 +141,21 @@ module Primer
             component.new(**system_arguments)
           },
         },
+        segmented_control: {
+          renders: lambda { |**system_arguments, &block|
+            deny_tag_argument(**system_arguments)
+
+            system_arguments = set_action_arguments(system_arguments, scheme: DEFAULT_ACTION_SCHEME)
+            mobile_args = system_arguments.delete(:mobile_system_arguments) || {}
+            @mobile_segmented_control = Primer::Alpha::SegmentedControl.new(**system_arguments,
+                                                                            **mobile_args,
+                                                                            mr: 2,
+                                                                            display: %i[flex none])
+            @mobile_segmented_control_block = block
+
+            Primer::Alpha::SegmentedControl.new(**system_arguments)
+          },
+        },
       }
 
       # Optional leading action prepend the title
@@ -252,7 +267,7 @@ module Primer
 
       def set_action_arguments(system_arguments, scheme: nil)
         system_arguments[:ml] ||= 2
-        system_arguments[:display] = [:none, :flex]
+        system_arguments[:display] = %i[none flex]
         system_arguments[:size] = :medium
         system_arguments[:scheme] = scheme unless scheme.nil?
         system_arguments[:classes] = class_names(

--- a/previews/primer/open_project/page_header_preview.rb
+++ b/previews/primer/open_project/page_header_preview.rb
@@ -40,7 +40,7 @@ module Primer
                                        with_leading_action: with_leading_action,
                                        with_actions: with_actions,
                                        breadcrumb_items: breadcrumb_items,
-                                       with_tab_nav: with_tab_nav})
+                                       with_tab_nav: with_tab_nav })
       end
 
       # @label Large title
@@ -71,8 +71,8 @@ module Primer
           component.with_breadcrumbs([{ href: "/foo", text: "Foo" }, { href: "/bar", text: "Bar" }, "Baz"])
 
           component.with_action_button(mobile_icon: "star", mobile_label: "Star") do |button|
-             button.with_leading_visual_icon(icon: "star")
-             "Star"
+            button.with_leading_visual_icon(icon: "star")
+            "Star"
           end
           component.with_action_menu(menu_arguments: { anchor_align: :end },
                                      button_arguments: { button_block: callback }) do |menu|
@@ -122,7 +122,6 @@ module Primer
           end
         end
       end
-
 
       # @label With a single action
       # The single action will not be transformed into a menu on mobile, but remains in a smaller variant
@@ -180,10 +179,59 @@ module Primer
           header.with_description { "Last updated 5 minutes ago by XYZ." }
           header.with_tab_nav(label: "label") do |nav|
             Array.new(3) do |i|
-              nav.with_tab(selected: i.zero? , href: "#") do |tab|
+              nav.with_tab(selected: i.zero?, href: "#") do |tab|
                 tab.with_text { "Tab #{i + 1}" }
               end
             end
+          end
+        end
+      end
+
+      # @label With a SegmentedControl
+      def segmented_control
+        render(Primer::OpenProject::PageHeader.new) do |component|
+          component.with_title { "Here's a segmented control" }
+          component.with_breadcrumbs(["Baz"])
+
+          component.with_action_segmented_control("aria-label": "Segmented control") do |control|
+            control.with_item(label: "Preview", icon: :eye, selected: true)
+            control.with_item(label: "Raw", icon: :"file-code")
+          end
+
+          component.with_action_button(mobile_icon: "star", mobile_label: "Star") do |button|
+            button.with_leading_visual_icon(icon: "star")
+            "Star"
+          end
+
+          callback = lambda do |button|
+            button.with_leading_visual_icon(icon: :gear)
+            "Settings"
+          end
+
+          component.with_action_menu(menu_arguments: { anchor_align: :end },
+                                     button_arguments: { button_block: callback }) do |menu|
+            menu.with_item(label: "Subitem 1") do |item|
+              item.with_leading_visual_icon(icon: :paste)
+            end
+            menu.with_item(label: "Subitem 2") do |item|
+              item.with_leading_visual_icon(icon: :log)
+            end
+          end
+        end
+      end
+
+      # @label With mobile icons-only SegmentedControl
+      def segmented_control_mobile_icons
+        render(Primer::OpenProject::PageHeader.new) do |component|
+          component.with_title { "Here's a segmented control" }
+          component.with_breadcrumbs(["Baz"])
+
+          component.with_action_segmented_control(
+            "aria-label": "Segmented control",
+            mobile_system_arguments: { hide_labels: true }
+          ) do |control|
+            control.with_item(label: "Preview", icon: :eye, selected: true)
+            control.with_item(label: "Raw", icon: :"file-code")
           end
         end
       end

--- a/test/components/primer/open_project/page_header_test.rb
+++ b/test/components/primer/open_project/page_header_test.rb
@@ -233,6 +233,20 @@ class PrimerOpenProjectPageHeaderTest < Minitest::Test
     assert_selector(".PageHeader-tabNav .tabnav-tab")
   end
 
+  def test_renders_segmented_control
+    render_inline(Primer::OpenProject::PageHeader.new) do |header|
+      header.with_title { "Hello" }
+      header.with_breadcrumbs(breadcrumb_elements)
+      header.with_action_segmented_control("aria-label": "Segmented control") do |control|
+        control.with_item(tag: :a, href: "#", label: "Preview", icon: :eye, selected: true)
+        control.with_item(tag: :a, href: "#", label: "Raw", icon: :"file-code")
+      end
+    end
+
+    assert_selector(".PageHeader-action")
+    assert_selector(".PageHeader-action.SegmentedControl")
+  end
+
   private
 
   def breadcrumb_elements


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Allow rendering a SegmentedControl as part of the PageHeader, that will always be present even on mobile

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
<img width="1023" alt="Bildschirmfoto 2024-06-12 um 10 58 20" src="https://github.com/primer/view_components/assets/459462/51302c92-72be-4ef7-8ed4-2902a1418efe">

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

https://community.openproject.org/work_packages/55639

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
