### PR TITLE
chore[Op#51376]: remove wrapping flex container that is causing caption and input group to be squeezed together

### DIFF
--- a/.changeset/sweet-jars-matter.md
+++ b/.changeset/sweet-jars-matter.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Remove wrapping flex container that reduced the spacing between the text input against the caption'

--- a/app/components/primer/open_project/input_group.html.erb
+++ b/app/components/primer/open_project/input_group.html.erb
@@ -5,8 +5,6 @@
   <% end %>
 
   <% if caption %>
-    <%= render(Primer::Beta::Text.new(tag: :div, display: :flex, direction: :column)) do %>
-      <%= caption %>
-    <% end %>
+    <%= caption %>
   <% end %>
 <% end %>


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

https://community.openproject.org/wp/51376

There is no longer adequate spacing between the caption and input group. The flex containers seem squashed together Let's use the simpler option

Follows https://github.com/opf/primer_view_components/pull/71

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

_Before_
![screenshot of caption and group squeezed together](https://github.com/opf/primer_view_components/assets/17295175/d15ebe86-53b1-4851-b0f7-283b137b7700)


_After_

![screenshot of preview with spacing between caption and input group](https://github.com/opf/primer_view_components/assets/17295175/0dba45f9-5a34-41cb-b85c-6fcaa5029464)

![screenshot in OP with correct spacing](https://github.com/opf/primer_view_components/assets/17295175/cd94471d-406c-457a-9fd8-850e49f7e91d)


#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

https://community.openproject.org/wp/51376

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

There is no longer adequate spacing between the caption and input group. The flex containers seem squashed together
Let's use the simpler option