### PR TITLE
[57542] Project list: Filter area shrinks when search bar is opened on mobile

### DIFF
--- a/.changeset/calm-ravens-lay.md
+++ b/.changeset/calm-ravens-lay.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Bottom pane of Primer::OpenProject::SubHeader remains full width when the search box is extended

--- a/app/components/primer/open_project/sub_header.pcss
+++ b/app/components/primer/open_project/sub_header.pcss
@@ -6,9 +6,10 @@
     grid-template-columns: auto 1fr auto;
     align-items: center;
     margin-bottom: 16px;
+}
 
-    /* When the filter input is expanded in mobile, we switch to a flex layout */
-    flex-wrap: wrap;
+.SubHeader--expandedSearch {
+    grid-template-areas: "left left left" "bottom bottom bottom";
 }
 
 .SubHeader-rightPane {

--- a/app/components/primer/open_project/sub_header_element.ts
+++ b/app/components/primer/open_project/sub_header_element.ts
@@ -15,7 +15,7 @@ class SubHeaderElement extends HTMLElement {
       item.classList.remove('d-none')
     }
 
-    this.classList.add('d-flex')
+    this.classList.add('SubHeader--expandedSearch')
 
     this.filterInput.focus()
   }
@@ -29,7 +29,7 @@ class SubHeaderElement extends HTMLElement {
       item.classList.add('d-none')
     }
 
-    this.classList.remove('d-flex')
+    this.classList.remove('SubHeader--expandedSearch')
   }
 }
 

--- a/static/classes.json
+++ b/static/classes.json
@@ -582,6 +582,9 @@
   "SubHeader": [
     "Primer::OpenProject::SubHeader"
   ],
+  "SubHeader--expandedSearch": [
+    "Primer::OpenProject::SubHeader"
+  ],
   "SubHeader-bottomPane": [
     "Primer::OpenProject::SubHeader"
   ],

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -182,6 +182,9 @@ class ComponentSpecificSelectorsTest < Minitest::Test
       ".InputGroup-input-width--large",
       ".InputGroup-input-width--xlarge",
       ".InputGroup-input-width--xxlarge",
+    ],
+    Primer::OpenProject::SubHeader => [
+      ".SubHeader--expandedSearch",
     ]
   }.freeze
 


### PR DESCRIPTION
### What are you trying to accomplish?
Expand the bottomPane to full width also when the search is expanded on mobile

### Screenshots
**Before**
<img width="551" alt="Bildschirmfoto 2024-09-02 um 09 21 35" src="https://github.com/user-attachments/assets/214652b8-5f81-4e3c-9cf4-ece039d1d6c9">

**after**
<img width="546" alt="Bildschirmfoto 2024-09-02 um 09 21 42" src="https://github.com/user-attachments/assets/33e1b223-21c2-46c8-8159-6881175c234a">


#### List the issues that this change affects.
Closes https://community.openproject.org/projects/openproject/work_packages/57542/activity
