### PR TITLE
Replace outdated variable

### DIFF
--- a/.changeset/happy-seas-leave.md
+++ b/.changeset/happy-seas-leave.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Introduce spacing below the PageHeader description again

--- a/app/components/primer/open_project/page_header.pcss
+++ b/app/components/primer/open_project/page_header.pcss
@@ -48,7 +48,7 @@
 }
 
 .PageHeader--withTabNav .PageHeader-description {
-  margin-bottom: var(--space-xlarge);
+  margin-bottom: var(--base-size-16);
 }
 
 .PageHeader-actions {


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/58128/activity

With primer primitives v9 `--space-xlarge` was outdated. It [was suggested](https://github.com/primer/primitives/pull/956/files#diff-975072a9730b4c5165cbf0a7ec49966c9fb69abb0feaeeddbabc3bd0ab4a1e46L61) to use `--base-size-16` instead. 