### PR TITLE
[58106] User tab headers overlap when header text is long

### DIFF
--- a/.changeset/gentle-grapes-help.md
+++ b/.changeset/gentle-grapes-help.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Avoid overlapping tabs in PageHeader tabNav

--- a/app/components/primer/open_project/page_header.html.erb
+++ b/app/components/primer/open_project/page_header.html.erb
@@ -30,5 +30,9 @@
   </div>
 
   <%= description %>
-  <%= tab_nav %>
+  <% if tab_nav %>
+    <div class="PageHeader-tabNavBar">
+      <%= tab_nav %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/components/primer/open_project/page_header.pcss
+++ b/app/components/primer/open_project/page_header.pcss
@@ -47,6 +47,14 @@
   flex: 1 100%;
 }
 
+.PageHeader-tabNavBar {
+  overflow: auto;
+}
+
+.PageHeader-tabNavBar .PageHeader-tabNav {
+  min-width: max-content;
+}
+
 .PageHeader--withTabNav .PageHeader-description {
   margin-bottom: var(--base-size-16);
 }

--- a/static/classes.json
+++ b/static/classes.json
@@ -483,6 +483,9 @@
   "PageHeader-parentLink": [
     "Primer::OpenProject::PageHeader"
   ],
+  "PageHeader-tabNavBar": [
+    "Primer::OpenProject::PageHeader"
+  ],
   "PageHeader-title": [
     "Primer::OpenProject::PageHeader"
   ],

--- a/test/components/primer/open_project/page_header_test.rb
+++ b/test/components/primer/open_project/page_header_test.rb
@@ -229,6 +229,7 @@ class PrimerOpenProjectPageHeaderTest < Minitest::Test
     end
 
     assert_selector(".PageHeader.PageHeader--withTabNav")
+    assert_selector(".PageHeader-tabNavBar")
     assert_selector(".PageHeader-tabNav")
     assert_selector(".PageHeader-tabNav .tabnav-tab")
   end


### PR DESCRIPTION
### What are you trying to accomplish?
Avoid overlapping tabs in PageHeader tabNav when the names of the tabs are long


#### List the issues that this change affects.
https://community.openproject.org/projects/openproject/work_packages/58106/activity

