### PR TITLE
[58256] header and sidebar menu should be hidden while pressing zen mode button 

### DIFF
--- a/.changeset/three-cooks-ring.md
+++ b/.changeset/three-cooks-ring.md
@@ -1,0 +1,5 @@
+---
+"@openproject/primer-view-components": patch
+---
+
+[58256] Add a click event listener for the button so we can listen to this event and make whatever changes that we want

--- a/app/components/primer/open_project/zen_mode_button.ts
+++ b/app/components/primer/open_project/zen_mode_button.ts
@@ -12,7 +12,13 @@ class ZenModeButtonElement extends HTMLElement {
   }
 
   triggerZenMode() {
-    const event = new CustomEvent('toggleZenMode')
+    // Create a new custom event
+    const event = new CustomEvent('toggleZenMode', {
+      detail: {
+        active: !this.inZenMode,
+      },
+    })
+    // Dispatch the custom event
     window.dispatchEvent(event)
   }
 

--- a/app/components/primer/open_project/zen_mode_button.ts
+++ b/app/components/primer/open_project/zen_mode_button.ts
@@ -5,21 +5,15 @@ class ZenModeButtonElement extends HTMLElement {
   @target button: HTMLElement
   inZenMode = false
 
-  // eslint-disable-next-line custom-elements/no-constructor
-  constructor() {
-    super()
-    this.button.addEventListener('click', this.triggerZenMode.bind(this))
-  }
-
-  triggerZenMode() {
+  isZenModeActivated() {
     // Create a new custom event
     const event = new CustomEvent('toggleZenMode', {
       detail: {
-        active: !this.inZenMode,
+        active: this.inZenMode,
       },
     })
     // Dispatch the custom event
-    window.dispatchEvent(event)
+    this.button.dispatchEvent(event)
   }
 
   private deactivateZenMode() {
@@ -44,6 +38,7 @@ class ZenModeButtonElement extends HTMLElement {
     } else {
       this.activateZenMode()
     }
+    this.isZenModeActivated()
   }
 }
 

--- a/app/components/primer/open_project/zen_mode_button.ts
+++ b/app/components/primer/open_project/zen_mode_button.ts
@@ -5,6 +5,17 @@ class ZenModeButtonElement extends HTMLElement {
   @target button: HTMLElement
   inZenMode = false
 
+  // eslint-disable-next-line custom-elements/no-constructor
+  constructor() {
+    super()
+    this.button.addEventListener('click', this.triggerZenMode.bind(this))
+  }
+
+  triggerZenMode() {
+    const event = new CustomEvent('toggleZenMode')
+    window.dispatchEvent(event)
+  }
+
   private deactivateZenMode() {
     this.inZenMode = false
     this.button.setAttribute('aria-pressed', 'false')

--- a/app/components/primer/open_project/zen_mode_button.ts
+++ b/app/components/primer/open_project/zen_mode_button.ts
@@ -5,15 +5,15 @@ class ZenModeButtonElement extends HTMLElement {
   @target button: HTMLElement
   inZenMode = false
 
-  isZenModeActivated() {
+  dispatchZenModeStatus() {
     // Create a new custom event
-    const event = new CustomEvent('toggleZenMode', {
+    const event = new CustomEvent('zenModeToggled', {
       detail: {
         active: this.inZenMode,
       },
     })
     // Dispatch the custom event
-    this.button.dispatchEvent(event)
+    window.dispatchEvent(event)
   }
 
   private deactivateZenMode() {
@@ -38,7 +38,7 @@ class ZenModeButtonElement extends HTMLElement {
     } else {
       this.activateZenMode()
     }
-    this.isZenModeActivated()
+    this.dispatchZenModeStatus()
   }
 }
 


### PR DESCRIPTION
### What are you trying to accomplish?
Add an event to this button while clicking on it. 

### Integration
We should listen to this event, then we can add or remove zen-mode class on body element.

Closes https://community.openproject.org/projects/openproject/work_packages/58256/activity

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
Add a click event for button, then in core we will listen to this event and show or hide the header and sidebar by adding or removing zen-mode class on body element. 

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [x] Tested in Edge
