### PR TITLE
[58256] Header and sidebar menu should be hidden while pressing zen mode button 

### DIFF
--- a/.changeset/large-kids-smile.md
+++ b/.changeset/large-kids-smile.md
@@ -1,0 +1,5 @@
+---
+"@openproject/primer-view-components": patch
+---
+
+[58256] Send an event when zen mode is activated and user press on escape button

--- a/app/components/primer/open_project/zen_mode_button.ts
+++ b/app/components/primer/open_project/zen_mode_button.ts
@@ -8,12 +8,13 @@ class ZenModeButtonElement extends HTMLElement {
   // eslint-disable-next-line custom-elements/no-constructor
   constructor() {
     super()
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this
-    document.addEventListener("fullscreenchange", (function() {
+    document.addEventListener('fullscreenchange', function () {
       if (!document.fullscreenElement && self.inZenMode) {
         self.performAction()
       }
-    }))
+    })
   }
 
   dispatchZenModeStatus() {

--- a/app/components/primer/open_project/zen_mode_button.ts
+++ b/app/components/primer/open_project/zen_mode_button.ts
@@ -8,15 +8,17 @@ class ZenModeButtonElement extends HTMLElement {
   // eslint-disable-next-line custom-elements/no-constructor
   constructor() {
     super()
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const self = this
-    document.addEventListener('fullscreenchange', function () {
-      if (!document.fullscreenElement && self.inZenMode) {
-        self.performAction()
-      }
-    })
+    document.addEventListener('fullscreenchange', this.fullscreenChangeEventHandler.bind(this))
   }
 
+  disconnectedCallback() {
+    document.removeEventListener('fullscreenchange', this.fullscreenChangeEventHandler.bind(this))
+  }
+
+  fullscreenChangeEventHandler() {
+    this.changeButtonState(!this.inZenMode)
+    this.dispatchZenModeStatus()
+  }
   dispatchZenModeStatus() {
     // Create a new custom event
     const event = new CustomEvent('zenModeToggled', {
@@ -29,19 +31,19 @@ class ZenModeButtonElement extends HTMLElement {
   }
 
   private deactivateZenMode() {
-    this.inZenMode = false
-    this.button.setAttribute('aria-pressed', 'false')
-    if (document.exitFullscreen && document.fullscreenElement) {
+    if (document.exitFullscreen) {
       void document.exitFullscreen()
     }
   }
 
   private activateZenMode() {
-    this.inZenMode = true
-    this.button.setAttribute('aria-pressed', 'true')
     if (document.documentElement.requestFullscreen) {
       void document.documentElement.requestFullscreen()
     }
+  }
+  public changeButtonState(inZenMode:boolean) {
+    this.inZenMode = inZenMode
+    this.button.setAttribute('aria-pressed', inZenMode.toString())
   }
 
   public performAction() {
@@ -50,7 +52,6 @@ class ZenModeButtonElement extends HTMLElement {
     } else {
       this.activateZenMode()
     }
-    this.dispatchZenModeStatus()
   }
 }
 

--- a/app/components/primer/open_project/zen_mode_button.ts
+++ b/app/components/primer/open_project/zen_mode_button.ts
@@ -41,7 +41,7 @@ class ZenModeButtonElement extends HTMLElement {
       void document.documentElement.requestFullscreen()
     }
   }
-  public changeButtonState(inZenMode:boolean) {
+  public changeButtonState(inZenMode: boolean) {
     this.inZenMode = inZenMode
     this.button.setAttribute('aria-pressed', inZenMode.toString())
   }

--- a/app/components/primer/open_project/zen_mode_button.ts
+++ b/app/components/primer/open_project/zen_mode_button.ts
@@ -5,6 +5,17 @@ class ZenModeButtonElement extends HTMLElement {
   @target button: HTMLElement
   inZenMode = false
 
+  // eslint-disable-next-line custom-elements/no-constructor
+  constructor() {
+    super()
+    const self = this
+    document.addEventListener("fullscreenchange", (function() {
+      if (!document.fullscreenElement && self.inZenMode) {
+        self.performAction()
+      }
+    }))
+  }
+
   dispatchZenModeStatus() {
     // Create a new custom event
     const event = new CustomEvent('zenModeToggled', {
@@ -19,7 +30,7 @@ class ZenModeButtonElement extends HTMLElement {
   private deactivateZenMode() {
     this.inZenMode = false
     this.button.setAttribute('aria-pressed', 'false')
-    if (document.exitFullscreen) {
+    if (document.exitFullscreen && document.fullscreenElement) {
       void document.exitFullscreen()
     }
   }


### PR DESCRIPTION
### What are you trying to accomplish?
Dispatch event when Zenmode is active and user press Escape button.

https://community.openproject.org/projects/openproject/work_packages/58256/activity

#### Risk Assessment

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
