### PR TITLE
[59233] update subheader primer component to accept custom actions on the left edge

### DIFF
--- a/.changeset/soft-carrots-notice.md
+++ b/.changeset/soft-carrots-notice.md
@@ -1,0 +1,5 @@
+---
+"@openproject/primer-view-components": patch
+---
+
+[59233] update subheader primer component to accept custom actions on the left edge

--- a/app/components/primer/open_project/sub_header.html.erb
+++ b/app/components/primer/open_project/sub_header.html.erb
@@ -1,5 +1,8 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <div class="SubHeader-leftPane">
+    <% left_actions.each do |action| %>
+      <%= action %>
+    <% end %>
     <%= render @filter_container do %>
       <%= filter_input %>
       <%= render @mobile_filter_cancel do

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -50,7 +50,7 @@ module Primer
           },
         },
         component: {
-          # A generic slot to render whatever component you like on the right side
+          # A generic slot to render whatever component you like on the left side
           renders: lambda { |**kwargs|
             deny_tag_argument(**kwargs)
             kwargs[:tag] = :div

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -34,6 +34,30 @@ module Primer
           },
         }
       }
+      # A button or custom content that will render on the left-hand side of the component.
+      #
+      # To render a button, call the `with_left_action_button` method, which accepts the arguments accepted by <%= link_to_component(Primer::Beta::Button) %>.
+      #
+      # To render custom content, call the `with_left_action_component` method and pass a block that returns HTML.
+      renders_many :left_actions, types: {
+        button: {
+          renders: lambda { |icon: nil, **kwargs|
+            if icon
+              Primer::Beta::IconButton.new(icon: icon, **kwargs)
+            else
+              Primer::Beta::Button.new(**kwargs)
+            end
+          },
+        },
+        component: {
+          # A generic slot to render whatever component you like on the right side
+          renders: lambda { |**kwargs|
+            deny_tag_argument(**kwargs)
+            kwargs[:tag] = :div
+            Primer::BaseComponent.new(**kwargs)
+          },
+        }
+      }
 
       renders_one :filter_input, lambda { |name:, label:, **system_arguments|
         system_arguments[:classes] = class_names(
@@ -132,9 +156,10 @@ module Primer
 
 
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**system_arguments)
+      def initialize(show_buttons_left: false, **system_arguments)
         @system_arguments = system_arguments
         @system_arguments[:tag] = :"sub-header"
+        @show_buttons_left = show_buttons_left
 
         @filter_container = Primer::BaseComponent.new(tag: :div,
                                                       classes: "SubHeader-filterContainer",

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -156,10 +156,9 @@ module Primer
 
 
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(show_buttons_left: false, **system_arguments)
+      def initialize(**system_arguments)
         @system_arguments = system_arguments
         @system_arguments[:tag] = :"sub-header"
-        @show_buttons_left = show_buttons_left
 
         @filter_container = Primer::BaseComponent.new(tag: :div,
                                                       classes: "SubHeader-filterContainer",

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -77,7 +77,7 @@ module Demo
           { assets: assets }
         end
       }
-      Lookbook.define_panel("assets", asset_panel_config)
+      Lookbook.add_panel("assets", asset_panel_config)
 
       config.lookbook.project_name = "Primer ViewComponents v#{Primer::ViewComponents::VERSION::STRING}"
       config.lookbook.preview_display_options = {

--- a/demo/config/initializers/custom_inputs.rb
+++ b/demo/config/initializers/custom_inputs.rb
@@ -3,8 +3,8 @@
 begin
   require "lookbook"
 
-  Lookbook.define_param_input(:octicon, "lookbook/previews/inputs/octicon")
-  Lookbook.define_param_input(:medium_octicon, "lookbook/previews/inputs/medium_octicon")
+  Lookbook.add_input_type(:octicon, "lookbook/previews/inputs/octicon")
+  Lookbook.add_input_type(:medium_octicon, "lookbook/previews/inputs/medium_octicon")
 rescue LoadError
   # Happens during docs:build, which runs in the context of the
   # PVC gem's bundle (i.e. not the demo app's bundle). Lookbook

--- a/previews/primer/open_project/sub_header_preview.rb
+++ b/previews/primer/open_project/sub_header_preview.rb
@@ -96,6 +96,11 @@ module Primer
           end
         end
       end
+
+      # @label With buttons in left side
+      def left_action_buttons
+        render_with_template(locals: {})
+      end
     end
   end
 end

--- a/previews/primer/open_project/sub_header_preview/left_action_buttons.html.erb
+++ b/previews/primer/open_project/sub_header_preview/left_action_buttons.html.erb
@@ -1,0 +1,17 @@
+<%= render(Primer::OpenProject::SubHeader.new(
+)) do |component| %>
+
+  <% component.with_action_component do %>
+    <%= render Primer::Alpha::ActionMenu.new(menu_id: "menu-1") do |menu|
+      menu.with_show_button(icon: :"op-kebab-vertical", "aria-label": "Menu")
+      menu.with_item(label: "Subitem 1") do |item|
+        item.with_leading_visual_icon(icon: :paste)
+      end
+      menu.with_item(label: "Subitem 2") do |item|
+        item.with_leading_visual_icon(icon: :log)
+      end
+    end  %>
+  <% end %>
+  <% component.with_left_action_button(scheme: :default) do "check" end %>
+  <% component.with_left_action_button(scheme: :default) do "uncheck" end %>
+<% end %>

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -56,6 +56,20 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
     assert_text("Button 1")
     assert_text("Button 2")
   end
+  def test_renders_a_custom_button_as_left_action
+    render_inline(Primer::OpenProject::SubHeader.new) do |component|
+      component.with_left_action_component do
+        "<div class='ButtonGroup'><div><button class='MyCustomClass'>Button 1</button></div><div><button class='MyCustomClass'>Button 2</button></div></div>".html_safe
+      end
+    end
+
+    assert_selector(".SubHeader")
+    assert_selector(".SubHeader-leftPane")
+    assert_selector(".SubHeader-leftPane .ButtonGroup")
+    assert_selector(".SubHeader-leftPane .MyCustomClass")
+    assert_text("Button 1")
+    assert_text("Button 2")
+  end
 
   def test_renders_a_text
     render_inline(Primer::OpenProject::SubHeader.new) do |component|

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -32,6 +32,17 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
     assert_selector(".SubHeader .Button--iconOnly")
   end
 
+  def test_renders_a_left_button_as_action
+    render_inline(Primer::OpenProject::SubHeader.new) do |component|
+      component.with_left_action_button(scheme: :default) do
+        "Check"
+      end
+    end
+
+    assert_selector(".SubHeader")
+    assert_selector(".SubHeader-leftPane .Button--secondary")
+  end
+
   def test_renders_a_custom_button_as_action
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
       component.with_action_component do

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -71,6 +71,15 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
     assert_text("Button 2")
   end
 
+  def test_renders_an_icon_button_as_left_action
+    render_inline(Primer::OpenProject::SubHeader.new) do |component|
+      component.with_left_action_button(icon: :plus, aria: { label: "Create" })
+    end
+
+    assert_selector(".SubHeader")
+    assert_selector(".SubHeader-leftPane .Button--iconOnly")
+  end
+
   def test_renders_a_text
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
       component.with_text { "Hello world!" }


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
Make the possibility to add left buttons in Subheader component.

### Screenshots
![Screenshot 2024-11-15 at 07 49 02](https://github.com/user-attachments/assets/abd7f94f-49e1-4db2-a432-d8111f952415)

### Integration
Left actions are optional for the component.

#### List the issues that this change affects.
https://community.openproject.org/projects/gmbh/work_packages/59233/activity

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
I defined left_actions which is the same asctions but will render on SubHeader-leftPane.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
