### PR TITLE
Commit generated Gemfile.lock

### DIFF
--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -350,6 +350,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21


### PR DESCRIPTION
### What are you trying to accomplish?

Running `bundle install` on macOS Sequoia 15.1.1 will add an entry for `arm64-darwin-24`.

It is annoying having a dirty working copy while trying to work on actual features.

### Screenshots

n/a

### Integration

n/a

#### List the issues that this change affects.

n/a

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

n/a

### Anything you want to highlight for special attention from reviewers?

n/a

### Accessibility

n/a

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
