### PR TITLE
`FeedbackDialog` and `DangerConfirmationDialog` yardoc improvements

### DIFF
--- a/app/components/primer/open_project/danger_confirmation_dialog.rb
+++ b/app/components/primer/open_project/danger_confirmation_dialog.rb
@@ -12,8 +12,10 @@ module Primer
 
       # A confirmation message with some defaults that are necessary for rendering nicely.
       #
-      # @param heading [String] the heading for the success message
-      # @param description [String] the description for the success message
+      # To render the message heading (required), call the `with_heading` method, which accepts a `:tag` argument, along with the arguments accepted by <%= link_to_component(Primer::Beta::Heading) %>.
+      #
+      # To render the message description, call the `with_description` method, which accepts <%= link_to_system_arguments_docs %>
+      #
       # @param icon_arguments [Hash] the system_arguments for the icon
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :confirmation_message, lambda { |icon_arguments: {}, **system_arguments|
@@ -27,6 +29,8 @@ module Primer
 
       # A checkbox that the user is required to check in order to continue with the destructive action.
       #
+      # To render the checkbox label (required), pass a block that returns a String.
+      #
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :confirmation_check_box, lambda { |**system_arguments|
         system_arguments[:display] ||= :flex
@@ -38,7 +42,7 @@ module Primer
         Primer::OpenProject::DangerConfirmationDialog::ConfirmationCheckBox.new(check_box_id: check_box_id, check_box_name: @check_box_name, **system_arguments)
       }
 
-      # Optional additional_details such as grid displaying a list of items to be deleted
+      # Optional additional details, such as grid displaying a list of items to be deleted
       #
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :additional_details, lambda { |**system_arguments|
@@ -57,11 +61,7 @@ module Primer
         Primer::BaseComponent.new(**system_arguments)
       }
 
-      # @param form_arguments [Hash] Allows the dialog to submit a form. Pass EITHER the `builder:` option to this hash
-      # to reuse an existing Rails form, or `action:` if you prefer the component to render the form tag itself.
-      # `builder:` should be an instance of `ActionView::Helpers::FormBuilder`, which is created by the standard Rails
-      # `#form_with` and `#form_for` helpers. The `name:` option is the desired name of the field that will be included
-      # in the params sent to the server on form submission.
+      # @param form_arguments [Hash] Allows the dialog to submit a form. Pass EITHER the `builder:` option to this hash to reuse an existing Rails form, or `action:` if you prefer the component to render the form tag itself. `builder:` should be an instance of `ActionView::Helpers::FormBuilder`, which is created by the standard Rails `#form_with` and `#form_for` helpers. The `name:` option is the desired name of the field that will be included in the params sent to the server on form submission.
       # @param id [String] The id of the dialog.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(

--- a/app/components/primer/open_project/feedback_dialog.rb
+++ b/app/components/primer/open_project/feedback_dialog.rb
@@ -6,10 +6,12 @@ module Primer
     class FeedbackDialog < Primer::Component
       status :open_project
 
-      # A feedback message with some defaults that are necessary for rendering nicely
+      # A feedback message with some defaults that are necessary for rendering nicely.
       #
-      # @param heading [String] the heading for the success message
-      # @param description [String] the description for the success message
+      # To render the message heading (required), call the `with_heading` method, which accepts a `:tag` argument, along with the arguments accepted by <%= link_to_component(Primer::Beta::Heading) %>.
+      #
+      # To render the message description, call the `with_description` method, which accepts <%= link_to_system_arguments_docs %>
+      #
       # @param icon_arguments [Hash] the system_arguments for the icon
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :feedback_message, lambda { |icon_arguments: {}, **system_arguments|
@@ -17,7 +19,7 @@ module Primer
         Primer::OpenProject::FeedbackMessage.new(icon_arguments: icon_arguments, **system_arguments)
       }
 
-      # Optional additional_details like a form input or toast.
+      # Optional additional details, like a form input or toast.
       #
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :additional_details, lambda { |**system_arguments|

--- a/static/arguments.json
+++ b/static/arguments.json
@@ -5117,7 +5117,7 @@
         "name": "form_arguments",
         "type": "Hash",
         "default": "`{}`",
-        "description": "Allows the dialog to submit a form. Pass EITHER the `builder:` option to this hash"
+        "description": "Allows the dialog to submit a form. Pass EITHER the `builder:` option to this hash to reuse an existing Rails form, or `action:` if you prefer the component to render the form tag itself. `builder:` should be an instance of `ActionView::Helpers::FormBuilder`, which is created by the standard Rails `#form_with` and `#form_for` helpers. The `name:` option is the desired name of the field that will be included in the params sent to the server on form submission."
       },
       {
         "name": "id",

--- a/static/info_arch.json
+++ b/static/info_arch.json
@@ -17453,7 +17453,7 @@
         "name": "form_arguments",
         "type": "Hash",
         "default": "`{}`",
-        "description": "Allows the dialog to submit a form. Pass EITHER the `builder:` option to this hash"
+        "description": "Allows the dialog to submit a form. Pass EITHER the `builder:` option to this hash to reuse an existing Rails form, or `action:` if you prefer the component to render the form tag itself. `builder:` should be an instance of `ActionView::Helpers::FormBuilder`, which is created by the standard Rails `#form_with` and `#form_for` helpers. The `name:` option is the desired name of the field that will be included in the params sent to the server on form submission."
       },
       {
         "name": "id",
@@ -17471,20 +17471,8 @@
     "slots": [
       {
         "name": "confirmation_message",
-        "description": "A confirmation message with some defaults that are necessary for rendering nicely.",
+        "description": "A confirmation message with some defaults that are necessary for rendering nicely.\n\nTo render the message heading (required), call the `with_heading` method, which accepts a `:tag` argument, along with the arguments accepted by {{#link_to_component}}Primer::Beta::Heading{{/link_to_component}}.\n\nTo render the message description, call the `with_description` method, which accepts {{link_to_system_arguments_docs}}",
         "parameters": [
-          {
-            "name": "heading",
-            "type": "String",
-            "default": "N/A",
-            "description": "the heading for the success message"
-          },
-          {
-            "name": "description",
-            "type": "String",
-            "default": "N/A",
-            "description": "the description for the success message"
-          },
           {
             "name": "icon_arguments",
             "type": "Hash",
@@ -17501,7 +17489,7 @@
       },
       {
         "name": "confirmation_check_box",
-        "description": "A checkbox that the user is required to check in order to continue with the destructive action.",
+        "description": "A checkbox that the user is required to check in order to continue with the destructive action.\n\nTo render the checkbox label (required), pass a block that returns a String.",
         "parameters": [
           {
             "name": "system_arguments",
@@ -17513,7 +17501,7 @@
       },
       {
         "name": "additional_details",
-        "description": "Optional additional_details such as grid displaying a list of items to be deleted",
+        "description": "Optional additional details, such as grid displaying a list of items to be deleted",
         "parameters": [
           {
             "name": "system_arguments",
@@ -17778,20 +17766,8 @@
     "slots": [
       {
         "name": "feedback_message",
-        "description": "A feedback message with some defaults that are necessary for rendering nicely",
+        "description": "A feedback message with some defaults that are necessary for rendering nicely.\n\nTo render the message heading (required), call the `with_heading` method, which accepts a `:tag` argument, along with the arguments accepted by {{#link_to_component}}Primer::Beta::Heading{{/link_to_component}}.\n\nTo render the message description, call the `with_description` method, which accepts {{link_to_system_arguments_docs}}",
         "parameters": [
-          {
-            "name": "heading",
-            "type": "String",
-            "default": "N/A",
-            "description": "the heading for the success message"
-          },
-          {
-            "name": "description",
-            "type": "String",
-            "default": "N/A",
-            "description": "the description for the success message"
-          },
           {
             "name": "icon_arguments",
             "type": "Hash",
@@ -17808,7 +17784,7 @@
       },
       {
         "name": "additional_details",
-        "description": "Optional additional_details like a form input or toast.",
+        "description": "Optional additional details, like a form input or toast.",
         "parameters": [
           {
             "name": "system_arguments",


### PR DESCRIPTION
⚠️ ~~**WARNING: includes commits from #224. Please review, merge that PR first.**~~

### What are you trying to accomplish?

Improve the accuracy of the documentation.
Groundwork for `DangerConfirmationDialog` documentation.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.

https://community.openproject.org/wp/60358

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [X] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
