### PR TITLE
Add I18n locale strings for demo app (en only)

### DIFF
--- a/demo/config/locales/en.yml
+++ b/demo/config/locales/en.yml
@@ -1,0 +1,11 @@
+en:
+  button_cancel: "Cancel"
+  button_close: "Close"
+  button_delete: "Delete"
+  button_delete_permanently: "Delete permanently"
+  button_filter: "Filter"
+  button_save: "Save"
+  label_more: "More"
+  label_loading: "Loading"
+  label_title: "Title"
+  label_zen_mode: "Zen mode"


### PR DESCRIPTION
### What are you trying to accomplish?

Copies a small subset of locale strings from @opf/openproject (en only) to the demo app for improved previews when running the lookbook locally and more accurate visual regression tests/screenshots.

### Screenshots

**Before**

<img width="516" alt="Screenshot 2025-01-17 at 00 50 09" src="https://github.com/user-attachments/assets/08f13e1f-5eae-4aa5-8a62-dc54a8efe8f0" />
<img width="289" alt="Screenshot 2025-01-17 at 00 49 59" src="https://github.com/user-attachments/assets/70bdd92d-e6b2-44e1-86f0-4a3efc332aa6" />

**After**

<img width="523" alt="Screenshot 2025-01-17 at 00 47 25" src="https://github.com/user-attachments/assets/7eb66f80-7e03-428b-8521-e25a06cd5c59" />
<img width="106" alt="Screenshot 2025-01-17 at 00 47 48" src="https://github.com/user-attachments/assets/8547e94e-d780-4aec-9700-9c4f7a144d35" />


### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

@HDinger I've changed my mind a bit on this issue - I think the cost of having to maintain separate I18n strings in this repo is probably pretty small. It brings the advantage of better DX when working oninthe lookbook locally, as well as better screenshots.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
