### PR TITLE
Fix Danger Dialog regression: unable to set custom button text

### DIFF
--- a/.changeset/gold-moles-beg.md
+++ b/.changeset/gold-moles-beg.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Fix regression: callers unable to set custom button text

--- a/app/components/primer/open_project/danger_dialog.rb
+++ b/app/components/primer/open_project/danger_dialog.rb
@@ -77,6 +77,9 @@ module Primer
         @form_wrapper = FormWrapper.new(**form_arguments)
         @dialog_id = id.to_s
 
+        @confirm_button_text = confirm_button_text
+        @cancel_button_text = cancel_button_text
+
         @system_arguments = system_arguments
         @system_arguments[:id] = @dialog_id
         @system_arguments[:classes] = class_names(

--- a/previews/primer/open_project/danger_dialog_preview/playground.html.erb
+++ b/previews/primer/open_project/danger_dialog_preview/playground.html.erb
@@ -1,4 +1,5 @@
 <%= render(Primer::OpenProject::DangerDialog.new(id: "my-dialog",
+                                                 title: "My dialog",
                                                  confirm_button_text: confirm_button_text,
                                                  cancel_button_text: cancel_button_text)) do |dialog| %>
   <% dialog.with_show_button { "Click me" } %>

--- a/test/components/primer/open_project/danger_dialog_test.rb
+++ b/test/components/primer/open_project/danger_dialog_test.rb
@@ -32,6 +32,22 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
     end
   end
 
+  def test_renders_default_with_custom_button_text
+    render_inline(Primer::OpenProject::DangerDialog.new(
+      confirm_button_text: "Do it!",
+      cancel_button_text: "Don't do it!"
+    )) do |dialog|
+      dialog.with_confirmation_message do |message|
+        message.with_heading(tag: :h2) { "Danger" }
+      end
+    end
+
+    assert_selector("dialog.DangerDialog") do
+      assert_selector(".Overlay-footer .Button", text: "Don't do it!")
+      assert_selector(".Overlay-footer .Button", text: "Do it!")
+    end
+  end
+
   def test_renders_with_confirmation_check_box
     render_inline(Primer::OpenProject::DangerDialog.new) do |dialog|
       dialog.with_confirmation_message do |message|
@@ -59,6 +75,23 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
     assert_selector("dialog.DangerDialog") do
       assert_selector(".Overlay-footer .Button", text: "en.button_cancel")
       assert_selector(".Overlay-footer .Button", text: "en.button_delete_permanently")
+    end
+  end
+
+  def test_renders_with_confirmation_check_box_custom_button_text
+    render_inline(Primer::OpenProject::DangerDialog.new(
+      confirm_button_text: "Do it FOREVER!",
+      cancel_button_text: "Nah"
+    )) do |dialog|
+      dialog.with_confirmation_message do |message|
+        message.with_heading(tag: :h2) { "Danger" }
+        dialog.with_confirmation_check_box { "I am sure about this deletion" }
+      end
+    end
+
+    assert_selector("dialog.DangerDialog") do
+      assert_selector(".Overlay-footer .Button", text: "Nah")
+      assert_selector(".Overlay-footer .Button", text: "Do it FOREVER!")
     end
   end
 

--- a/test/system/open_project/danger_dialog_test.rb
+++ b/test/system/open_project/danger_dialog_test.rb
@@ -36,6 +36,17 @@ class IntegrationOpenProjectDangerDialogTest < System::TestCase
     end
   end
 
+  def test_playground_custom_button_text
+    visit_preview(:playground, confirm_button_text: "Löschen", cancel_button_text: "Abbrechen")
+
+    click_button("Click me")
+    assert_selector(".DangerDialog")
+    within(".DangerDialog") do
+      assert_selector("button[data-submit-dialog-id]", text: "Löschen")
+      assert_selector("button[data-close-dialog-id]", text: "Abbrechen")
+    end
+  end
+
   def test_submit_button_submits_form
     visit_preview(:with_form_test, route_format: :json)
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes a regression in 0.53.0 where callers are unable to set custom button text for the Danger Dialog.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.


#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
