### PR TITLE
Make title param required for DangerDialog and FeedbackDialog

### DIFF
--- a/.changeset/nasty-oranges-end.md
+++ b/.changeset/nasty-oranges-end.md
@@ -1,0 +1,7 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Make DangerDialog title param required: Axe will raise accessibility violations in the absence of a title. We want to ensure best a11y practice, so this change makes it a required param and documents it.
+
+This is a BREAKING change.

--- a/.changeset/polite-toys-tap.md
+++ b/.changeset/polite-toys-tap.md
@@ -1,0 +1,7 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Make FeedbackDialog title param required: Axe will raise accessibility violations in the absence of a title. We want to ensure best a11y practice, so this change makes it a required param and documents it.
+
+This is a BREAKING change.

--- a/app/components/primer/open_project/danger_dialog.rb
+++ b/app/components/primer/open_project/danger_dialog.rb
@@ -63,12 +63,14 @@ module Primer
 
       # @param form_arguments [Hash] Allows the dialog to submit a form. Pass EITHER the `builder:` option to this hash to reuse an existing Rails form, or `action:` if you prefer the component to render the form tag itself. `builder:` should be an instance of `ActionView::Helpers::FormBuilder`, which is created by the standard Rails `#form_with` and `#form_for` helpers. The `name:` option is the desired name of the field that will be included in the params sent to the server on form submission.
       # @param id [String] The id of the dialog.
+      # @param title [String] The title of the dialog. Although visually hidden, a label is rendered for assistive technologies.
       # @param confirm_button_text [String] The text of the confirm button. Will default to `I18n.t("button_delete")`, or `I18n.t("button_delete_permanently")` if `confirmation_check_box` slot has been passed to the component.
       # @param cancel_button_text [String] The text of the cancel button. Will default to `I18n.t("button_cancel")`.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(
         form_arguments: {},
         id: self.class.generate_id,
+        title:,
         confirm_button_text: nil,
         cancel_button_text: nil,
         **system_arguments
@@ -87,7 +89,7 @@ module Primer
           "DangerDialog"
         )
 
-        @dialog = Primer::Alpha::Dialog.new(title: @system_arguments[:title], subtitle: nil, visually_hide_title: true, **@system_arguments)
+        @dialog = Primer::Alpha::Dialog.new(title: title, subtitle: nil, visually_hide_title: true, **@system_arguments)
       end
 
       delegate :labelledby, :header?, :header, :with_header, :with_header_content,

--- a/app/components/primer/open_project/feedback_dialog.rb
+++ b/app/components/primer/open_project/feedback_dialog.rb
@@ -40,8 +40,9 @@ module Primer
 
       renders_one :footer
 
+      # @param title [String] The title of the dialog. Although visually hidden, a label is rendered for assistive technologies.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**system_arguments)
+      def initialize(title:, **system_arguments)
         @system_arguments = system_arguments
         @system_arguments[:classes] = class_names(
           system_arguments[:classes],
@@ -49,7 +50,7 @@ module Primer
         )
         @system_arguments[:id] ||= self.class.generate_id
 
-        @dialog = Primer::Alpha::Dialog.new(title: @system_arguments[:title], subtitle: nil, visually_hide_title: true, **@system_arguments)
+        @dialog = Primer::Alpha::Dialog.new(title: title, subtitle: nil, visually_hide_title: true, **@system_arguments)
       end
 
       delegate :header?, :header, :with_header, :with_header_content,

--- a/previews/primer/open_project/danger_dialog_preview/with_additional_details.html.erb
+++ b/previews/primer/open_project/danger_dialog_preview/with_additional_details.html.erb
@@ -1,4 +1,4 @@
-<%= render(Primer::OpenProject::DangerDialog.new) do |dialog| %>
+<%= render(Primer::OpenProject::DangerDialog.new(title: "Delete work packages")) do |dialog| %>
   <% dialog.with_show_button { "Click me" } %>
   <% dialog.with_confirmation_message do |message| %>
     <% message.with_heading(tag: :h2).with_content("Delete 5 work packages?") %>

--- a/previews/primer/open_project/feedback_dialog_preview/playground.html.erb
+++ b/previews/primer/open_project/feedback_dialog_preview/playground.html.erb
@@ -1,4 +1,4 @@
-<%= render(Primer::OpenProject::FeedbackDialog.new(id: "my-dialog")) do |dialog| %>
+<%= render(Primer::OpenProject::FeedbackDialog.new(id: "my-dialog", title: "My dialog")) do |dialog| %>
   <% dialog.with_show_button { "Click me" } %>
   <% dialog.with_feedback_message(icon_arguments: { icon: icon, color: icon_color }, loading: loading_state) do |message| %>
     <% message.with_heading(tag: :h2).with_content("Awesome!") %>

--- a/previews/primer/open_project/feedback_dialog_preview/with_additional_details.html.erb
+++ b/previews/primer/open_project/feedback_dialog_preview/with_additional_details.html.erb
@@ -1,4 +1,4 @@
-<%= render(Primer::OpenProject::FeedbackDialog.new) do |dialog| %>
+<%= render(Primer::OpenProject::FeedbackDialog.new(title: "Success message")) do |dialog| %>
   <% dialog.with_show_button { "Click me" } %>
   <% dialog.with_feedback_message do |message| %>
     <% message.with_heading(tag: :h2).with_content("Action successful") %>

--- a/previews/primer/open_project/feedback_dialog_preview/with_custom_footer.html.erb
+++ b/previews/primer/open_project/feedback_dialog_preview/with_custom_footer.html.erb
@@ -1,4 +1,4 @@
-<%= render(Primer::OpenProject::FeedbackDialog.new(id: "my-dialog")) do |dialog| %>
+<%= render(Primer::OpenProject::FeedbackDialog.new(id: "my-dialog", title: "Custom footer")) do |dialog| %>
   <% dialog.with_show_button { "Click me" } %>
   <% dialog.with_feedback_message do |message| %>
     <% message.with_heading(tag: :h2).with_content("Action successful") %>

--- a/static/arguments.json
+++ b/static/arguments.json
@@ -5221,6 +5221,12 @@
     "lookbook": "https://primer.style/view-components/lookbook/inspect/primer/open_project/feedback_dialog/default/",
     "parameters": [
       {
+        "name": "title",
+        "type": "String",
+        "default": "N/A",
+        "description": "The title of the dialog. Although visually hidden, a label is rendered for assistive technologies."
+      },
+      {
         "name": "system_arguments",
         "type": "Hash",
         "default": "N/A",

--- a/static/arguments.json
+++ b/static/arguments.json
@@ -5132,6 +5132,12 @@
         "description": "The id of the dialog."
       },
       {
+        "name": "title",
+        "type": "String",
+        "default": "N/A",
+        "description": "The title of the dialog. Although visually hidden, a label is rendered for assistive technologies."
+      },
+      {
         "name": "confirm_button_text",
         "type": "String",
         "default": "`nil`",

--- a/static/info_arch.json
+++ b/static/info_arch.json
@@ -17533,6 +17533,12 @@
         "description": "The id of the dialog."
       },
       {
+        "name": "title",
+        "type": "String",
+        "default": "N/A",
+        "description": "The title of the dialog. Although visually hidden, a label is rendered for assistive technologies."
+      },
+      {
         "name": "confirm_button_text",
         "type": "String",
         "default": "`nil`",

--- a/static/info_arch.json
+++ b/static/info_arch.json
@@ -17885,6 +17885,12 @@
     "lookbook": "https://primer.style/view-components/lookbook/inspect/primer/open_project/feedback_dialog/default/",
     "parameters": [
       {
+        "name": "title",
+        "type": "String",
+        "default": "N/A",
+        "description": "The title of the dialog. Although visually hidden, a label is rendered for assistive technologies."
+      },
+      {
         "name": "system_arguments",
         "type": "Hash",
         "default": "N/A",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -8,7 +8,7 @@ class PrimerComponentTest < Minitest::Test
 
   # Components with any arguments necessary to make them render
   COMPONENTS_WITH_ARGS = [
-    [Primer::OpenProject::DangerDialog, {}, proc { |component|
+    [Primer::OpenProject::DangerDialog, { title: "Danger action" }, proc { |component|
       component.with_confirmation_message do |confirmation|
         confirmation.with_heading(tag: :h2) { "Live dangerously?" }
       end

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -15,7 +15,7 @@ class PrimerComponentTest < Minitest::Test
       component.with_confirmation_check_box { "Really do this?" }
     }],
     [Primer::OpenProject::DangerDialog::ConfirmationCheckBox, { check_box_name: "foo" }, proc { "Foo" }],
-    [Primer::OpenProject::FeedbackDialog, {}, proc { |component|
+    [Primer::OpenProject::FeedbackDialog, { title: "Useful feedback" }, proc { |component|
       component.with_feedback_message do |feedback|
         feedback.with_heading(tag: :h2) { "You are a hero" }
       end

--- a/test/components/primer/open_project/danger_dialog_test.rb
+++ b/test/components/primer/open_project/danger_dialog_test.rb
@@ -6,7 +6,7 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
   def test_renders_default
-    render_inline(Primer::OpenProject::DangerDialog.new) do |dialog|
+    render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger action")) do |dialog|
       dialog.with_confirmation_message do |message|
         message.with_heading(tag: :h2) { "Danger" }
       end
@@ -20,7 +20,7 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
   end
 
   def test_renders_default_button_text
-    render_inline(Primer::OpenProject::DangerDialog.new) do |dialog|
+    render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger action")) do |dialog|
       dialog.with_confirmation_message do |message|
         message.with_heading(tag: :h2) { "Danger" }
       end
@@ -34,6 +34,7 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
 
   def test_renders_default_with_custom_button_text
     render_inline(Primer::OpenProject::DangerDialog.new(
+      title: "Danger action",
       confirm_button_text: "Do it!",
       cancel_button_text: "Don't do it!"
     )) do |dialog|
@@ -49,7 +50,7 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
   end
 
   def test_renders_with_confirmation_check_box
-    render_inline(Primer::OpenProject::DangerDialog.new) do |dialog|
+    render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger confirmation action")) do |dialog|
       dialog.with_confirmation_message do |message|
         message.with_heading(tag: :h2) { "Danger" }
       end
@@ -65,7 +66,7 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
   end
 
   def test_renders_with_confirmation_check_box_button_text
-    render_inline(Primer::OpenProject::DangerDialog.new) do |dialog|
+    render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger confirmation action")) do |dialog|
       dialog.with_confirmation_message do |message|
         message.with_heading(tag: :h2) { "Danger" }
       end
@@ -80,6 +81,7 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
 
   def test_renders_with_confirmation_check_box_custom_button_text
     render_inline(Primer::OpenProject::DangerDialog.new(
+      title: "Danger confirmation action",
       confirm_button_text: "Do it FOREVER!",
       cancel_button_text: "Nah"
     )) do |dialog|
@@ -97,7 +99,7 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
 
   def test_does_not_render_if_no_confirmation_message_provided
     error = assert_raises(ArgumentError) do
-      render_inline(Primer::OpenProject::DangerDialog.new)
+      render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger action"))
     end
 
     assert_equal "DangerDialog requires a confirmation_message", error.message
@@ -105,7 +107,7 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
 
   def test_does_not_render_if_no_confirmation_check_box_content_provided
     error = assert_raises(ArgumentError) do
-      render_inline(Primer::OpenProject::DangerDialog.new) do |dialog|
+      render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger confirmation action")) do |dialog|
         dialog.with_confirmation_message do |message|
           message.with_heading(tag: :h2) { "Danger" }
         end
@@ -117,7 +119,7 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
   end
 
   def test_renders_without_form_by_default
-    render_inline(Primer::OpenProject::DangerDialog.new) do |dialog|
+    render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger confirmation action")) do |dialog|
       dialog.with_confirmation_message do |message|
         message.with_heading(tag: :h2) { "Danger" }
       end
@@ -130,7 +132,7 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
   end
 
   def test_renders_button_type_buttons_by_default
-    render_inline(Primer::OpenProject::DangerDialog.new) do |dialog|
+    render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger confirmation action")) do |dialog|
       dialog.with_confirmation_message do |message|
         message.with_heading(tag: :h2) { "Danger" }
       end
@@ -147,7 +149,10 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
     error = assert_raises do
       render_in_view_context do
         form_with(url: "/my-action", method: :delete) do |f|
-          render(Primer::OpenProject::DangerDialog.new(form_arguments: { builder: f, action: "/my-action" })) do |dialog|
+          render(Primer::OpenProject::DangerDialog.new(
+            title: "Danger confirmation action",
+            form_arguments: { builder: f, action: "/my-action" })
+          ) do |dialog|
             dialog.with_confirmation_message do |message|
               message.with_heading(tag: :h2) { "Danger" }
             end
@@ -162,7 +167,8 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
 
   def test_renders_form_with_form_arguments
     render_inline(Primer::OpenProject::DangerDialog.new(
-       form_arguments: { action: "/my-action", method: :delete, name: "custom_check" }
+      title: "Danger confirmation action",
+      form_arguments: { action: "/my-action", method: :delete, name: "custom_check" }
      )) do |dialog|
        dialog.with_confirmation_message do |message|
          message.with_heading(tag: :h2) { "Danger" }
@@ -180,6 +186,7 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
 
   def test_renders_submit_type_button_with_form_arguments
     render_inline(Primer::OpenProject::DangerDialog.new(
+      title: "Danger confirmation action",
       form_arguments: { action: "/my-action", method: :delete }
     )) do |dialog|
       dialog.with_confirmation_message do |message|
@@ -197,7 +204,10 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
   def test_renders_submit_type_button_with_form_builder_form_arguments
     render_in_view_context do
       form_with(url: "/my-action", method: :delete) do |f|
-        render(Primer::OpenProject::DangerDialog.new(form_arguments: { builder: f })) do |dialog|
+        render(Primer::OpenProject::DangerDialog.new(
+          title: "Danger confirmation action",
+          form_arguments: { builder: f })
+        ) do |dialog|
           dialog.with_confirmation_message do |message|
             message.with_heading(tag: :h2) { "Danger" }
           end
@@ -213,7 +223,9 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
   end
 
   def test_renders_provided_id
-    render_inline(Primer::OpenProject::DangerDialog.new(id: "danger-dialog")) do |dialog|
+    render_inline(Primer::OpenProject::DangerDialog.new(
+      id: "danger-dialog", title: "Danger confirmation action"
+    )) do |dialog|
       dialog.with_confirmation_message do |message|
         message.with_heading(tag: :h2) { "Danger" }
       end
@@ -227,7 +239,7 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
   end
 
   def test_renders_additional_details
-    render_inline(Primer::OpenProject::DangerDialog.new) do |dialog|
+    render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger confirmation action")) do |dialog|
       dialog.with_confirmation_message do |message|
         message.with_heading(tag: :h2) { "Danger" }
       end

--- a/test/components/primer/open_project/feedback_dialog_test.rb
+++ b/test/components/primer/open_project/feedback_dialog_test.rb
@@ -6,7 +6,7 @@ class PrimerOpenProjectFeedbackDialogTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
   def test_renders
-    render_inline(Primer::OpenProject::FeedbackDialog.new) do |dialog|
+    render_inline(Primer::OpenProject::FeedbackDialog.new(title: "Success message")) do |dialog|
       dialog.with_feedback_message do |message|
         message.with_heading(tag: :h2) { "Success" }
       end
@@ -20,7 +20,7 @@ class PrimerOpenProjectFeedbackDialogTest < Minitest::Test
   end
 
   def test_renders_additional_details
-    render_inline(Primer::OpenProject::FeedbackDialog.new) do |dialog|
+    render_inline(Primer::OpenProject::FeedbackDialog.new(title: "Success message")) do |dialog|
       dialog.with_feedback_message do |message|
         message.with_heading(tag: :h2) { "Success" }
       end
@@ -33,7 +33,7 @@ class PrimerOpenProjectFeedbackDialogTest < Minitest::Test
   end
 
   def test_renders_custom_footer
-    render_inline(Primer::OpenProject::FeedbackDialog.new) do |dialog|
+    render_inline(Primer::OpenProject::FeedbackDialog.new(title: "Success message")) do |dialog|
       dialog.with_feedback_message do |message|
         message.with_heading(tag: :h2) { "Success" }
       end
@@ -46,7 +46,7 @@ class PrimerOpenProjectFeedbackDialogTest < Minitest::Test
   end
 
   def test_renders_custom_icon
-    render_inline(Primer::OpenProject::FeedbackDialog.new) do |dialog|
+    render_inline(Primer::OpenProject::FeedbackDialog.new(title: "Error message")) do |dialog|
       dialog.with_feedback_message(icon_arguments: { icon: :"x-circle", color: :danger }) do |message|
         message.with_heading(tag: :h2) { "Ups, something went wrong" }
         message.with_description { "Please try again or contact your administrator if the issue persists." }
@@ -61,7 +61,7 @@ class PrimerOpenProjectFeedbackDialogTest < Minitest::Test
   end
 
   def test_renders_loading_spinner
-    render_inline(Primer::OpenProject::FeedbackDialog.new) do |dialog|
+    render_inline(Primer::OpenProject::FeedbackDialog.new(title: "Loading...")) do |dialog|
       dialog.with_feedback_message(loading: true) do |message|
         message.with_heading(tag: :h2) { "Ups, something went wrong" }
       end


### PR DESCRIPTION
### What are you trying to accomplish?

Makes title param required for **DangerDialog** and **FeedbackDialog**: Axe will raise accessibility violations in the absence of a title. We want to ensure best a11y practice, so this change makes it a required param and documents it.

This is a BREAKING change.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration



#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

### Anything you want to highlight for special attention from reviewers?


### Accessibility

- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.

Fixes Axe scan violations if a title is not specified for a preview:

```
IntegrationOpenProjectDangerDialogTest#test_playground_custom_button_text [test/system/open_project/danger_dialog_test.rb:42]:

    Found 1 accessibility violations:
    
    1) empty-heading: Ensures headings have discernible text (minor)
    https://dequeuniversity.com/rules/axe/4.9/empty-heading?application=axeAPI
    The following 4 node violate this rule:
      Selector: #my-dialog-title
      HTML: <h1 class="Overlay-title sr-only" id="my-dialog-title">
        
      </h1>
      Fix any of the following:
      - - Element does not have text that is visible to screen readers- aria-label attribute does not exist or is empty- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty- Element has no title attribute
    Selector: #my-dialog-title
      HTML: <h1 class="Overlay-title sr-only" id="my-dialog-title">
        
      </h1>
```


### Merge checklist

- [X] Added/updated tests
- [X] Added/updated documentation
- [X] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [X] Tested in Safari
- [ ] Tested in Edge
