### PR TITLE
[#61546] Fix DangerDialog scroll behaviour w/form

### DIFF
--- a/.changeset/soft-pots-return.md
+++ b/.changeset/soft-pots-return.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Fix DangerDialog body scroll behaviour when containing a form: the dialog's confirm and cancel buttons should now always be visible in the viewport, never scrolling with the other dialog content.

--- a/app/components/primer/open_project/danger_dialog_form_helper.ts
+++ b/app/components/primer/open_project/danger_dialog_form_helper.ts
@@ -6,12 +6,21 @@ const SUBMIT_BUTTON_SELECTOR = 'input[type=submit],button[type=submit],button[da
 class DangerDialogFormHelperElement extends HTMLElement {
   @target checkbox: HTMLInputElement | undefined
 
+  get form() {
+    return this.querySelector('form')
+  }
+
   get submitButton() {
     return this.querySelector<HTMLInputElement | HTMLButtonElement>(SUBMIT_BUTTON_SELECTOR)!
   }
 
   connectedCallback() {
+    // makes the custom element behave as if it doesn't exist in the DOM structure, passing all
+    // styles directly to its children.
     this.style.display = 'contents'
+    if (this.form) {
+      this.form.style.display = 'contents'
+    }
     this.#reset()
   }
 


### PR DESCRIPTION
⚠️ **See #244 for system tests for this bugfix**

### What are you trying to accomplish?

Fix Danger Dialog scroll behaviour when the dialog contains a form.

<details><summary>Note on using Form Builders</summary>
<p>
N.B. this issue only occurs when the `form` element is rendered inside the dialog, which in turn only happens when an `action` rather than `builder` is passed as `form_arguments`.

https://qa.openproject-edge.com/lookbook/inspect/primer/open_project/danger_dialog/with_form (incorrect scroll behaviour)

https://qa.openproject-edge.com/lookbook/inspect/primer/open_project/danger_dialog/with_form_builder_form (behaves as expected)
</p>
</details> 



### Screenshots

**Before**

<img width="542" alt="Before fix" src="https://github.com/user-attachments/assets/e25d5121-de7e-412c-8a13-bc8c47edbf4d" />

**After**

<img width="543" alt="After fix" src="https://github.com/user-attachments/assets/f48d8080-3014-44e9-a74e-f66c14c5e4cb" />

### Integration

No changes necessary.

#### List the issues that this change affects.

https://community.openproject.org/wp/61546

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

This PR also applies `display: contents` to the `form` element when present.

See commit 10e03e77c2f71771bfff3ec7a1c13b9afdfe77dc (PR opf/primer_view_components#234)

### Anything you want to highlight for special attention from reviewers?

N/A

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
