### PR TITLE
[#61546] Fix DangerDialog scroll behaviour w/form + system test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :development do
   gem "allocation_stats", "~> 0.1"
   gem "benchmark-ips", "~> 2.13.0"
   gem "capybara", "~> 3.40.0"
-  gem "cuprite", "~> 0.15"
+  gem "cuprite", "~> 0.15", github: "myabc/cuprite", branch: "feature/support-node-obscured"
   gem "debug"
   gem "erb_lint", "~> 0.6"
   gem "erblint-github", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/myabc/cuprite.git
+  revision: d29cde6c0f3b0eed4325a7be8ad9c146bff0ddb2
+  branch: feature/support-node-obscured
+  specs:
+    cuprite (0.15.1)
+      capybara (~> 3.0)
+      ferrum (~> 0.16.0)
+
 PATH
   remote: .
   specs:
@@ -38,8 +47,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     allocation_stats (0.1.5)
     ansi (1.5.0)
     ast (2.4.2)
@@ -66,7 +75,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     coderay (1.1.3)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.5)
     connection_pool (2.4.1)
     crack (1.0.0)
       bigdecimal
@@ -76,9 +85,6 @@ GEM
       addressable
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
-    cuprite (0.15)
-      capybara (~> 3.0)
-      ferrum (~> 0.14.0)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -94,11 +100,12 @@ GEM
       smart_properties
     erblint-github (1.0.1)
     erubi (1.13.0)
-    ferrum (0.14)
+    ferrum (0.16)
       addressable (~> 2.5)
+      base64 (~> 0.2)
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
-      websocket-driver (>= 0.6, < 0.8)
+      websocket-driver (~> 0.7)
     ffi (1.16.3)
     hashdiff (1.1.0)
     htmlbeautifier (1.4.3)
@@ -135,17 +142,17 @@ GEM
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.7)
+    mini_portile2 (2.8.8)
     minitest (5.25.1)
     mocha (2.3.0)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.7.2)
     mutex_m (0.2.0)
     nio4r (2.7.3)
-    nokogiri (1.16.7)
+    nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-linux)
+    nokogiri (1.18.3-x86_64-linux-gnu)
       racc (~> 1.4)
     openproject-octicons (19.20.0)
     parallel (1.26.3)
@@ -157,18 +164,18 @@ GEM
       method_source (~> 1.0)
     psych (5.1.2)
       stringio
-    public_suffix (5.0.5)
+    public_suffix (6.0.1)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.7)
+    rack (3.1.10)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-proxy (0.7.7)
       rack
     rack-session (2.0.0)
       rack (>= 3.0.0)
-    rack-test (2.1.0)
+    rack-test (2.2.0)
       rack (>= 1.3)
     rackup (2.1.0)
       rack (>= 3)
@@ -196,7 +203,7 @@ GEM
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
-    regexp_parser (2.9.2)
+    regexp_parser (2.10.0)
     reline (0.5.10)
       io-console (~> 0.5)
     rexml (3.3.7)
@@ -277,9 +284,10 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
+    webrick (1.9.1)
     websocket (1.2.10)
-    websocket-driver (0.7.6)
+    websocket-driver (0.7.7)
+      base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
@@ -300,7 +308,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   capybara (~> 3.40.0)
   cssbundling-rails (~> 1.4)
-  cuprite (~> 0.15)
+  cuprite (~> 0.15)!
   debug
   erb_lint (~> 0.6)
   erblint-github (~> 1.0)

--- a/previews/primer/open_project/danger_dialog_preview.rb
+++ b/previews/primer/open_project/danger_dialog_preview.rb
@@ -96,6 +96,12 @@ module Primer
       def with_form_test(route_format: :html)
         render_with_template(locals: { route_format: route_format })
       end
+
+      # @label With form and long additional details for testing purposes
+      # @hidden
+      def with_form_long_additional_details_test(route_format: :html)
+        render_with_template(locals: { route_format: route_format })
+      end
     end
   end
 end

--- a/previews/primer/open_project/danger_dialog_preview/with_form_long_additional_details_test.html.erb
+++ b/previews/primer/open_project/danger_dialog_preview/with_form_long_additional_details_test.html.erb
@@ -1,0 +1,14 @@
+<%= render(Primer::OpenProject::DangerDialog.new(
+    title: "Delete dialog",
+    form_arguments: { action: generic_form_submission_path(route_format) }
+  )) do |dialog| %>
+  <% dialog.with_show_button { "Click me" } %>
+  <% dialog.with_confirmation_message do |message|
+      message.with_heading(tag: :h2).with_content("Permanently delete this item?")
+      message.with_description_content("This action is not reversible. Please proceed with caution.")
+     end %>
+  <% dialog.with_additional_details do %>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nunc tellus, finibus vitae purus vitae, venenatis sodales nibh. Duis orci quam, vehicula sed iaculis et, dignissim vel felis. Cras ac pretium nisl. Proin efficitur vehicula dui, eu pulvinar neque convallis et. Nam interdum imperdiet urna, at aliquam lectus mattis nec. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec cursus dolor et eros ornare, id pretium magna interdum. Cras cursus lorem eu semper bibendum. Nulla facilisi. In accumsan dignissim arcu vel congue. Sed auctor lacus ipsum, vitae posuere purus scelerisque ac. Suspendisse tincidunt justo eget libero luctus semper. Vivamus vitae erat ut erat malesuada volutpat.</p>
+  <% end %>
+  <% dialog.with_confirmation_check_box_content("I understand that this deletion cannot be reversed") %>
+<% end %>

--- a/test/system/open_project/danger_dialog_test.rb
+++ b/test/system/open_project/danger_dialog_test.rb
@@ -66,7 +66,7 @@ class IntegrationOpenProjectDangerDialogTest < System::TestCase
 
   def test_buttons_visible_without_scrolling_with_form
     visit_preview(:with_form_long_additional_details_test, route_format: :json)
-    window.resize(width: window.viewport_size[0], height: 250)
+    window.resize(height: 250)
 
     click_button("Click me")
 

--- a/test/system/open_project/danger_dialog_test.rb
+++ b/test/system/open_project/danger_dialog_test.rb
@@ -3,6 +3,8 @@
 require "system/test_case"
 
 class IntegrationOpenProjectDangerDialogTest < System::TestCase
+  include Primer::WindowTestHelpers
+
   def test_submit_button_enabled_on_dialog_open_default
     visit_preview(:default)
 
@@ -60,6 +62,18 @@ class IntegrationOpenProjectDangerDialogTest < System::TestCase
 
     form_params = JSON.parse(page.document.text)["form_params"]
     assert_equal "1", form_params["confirm_dangerous_action"]
+  end
+
+  def test_buttons_visible_without_scrolling_with_form
+    visit_preview(:with_form_long_additional_details_test, route_format: :json)
+    window.resize(width: window.viewport_size[0], height: 250)
+
+    click_button("Click me")
+
+    assert_selector(".DangerDialog") do
+      assert_selector("button[data-close-dialog-id]", obscured: false)
+      assert_selector("button[data-submit-dialog-id]", obscured: false)
+    end
   end
 
   def test_submit_button_submits_form_builder_form

--- a/test/test_helpers/window_test_helpers.rb
+++ b/test/test_helpers/window_test_helpers.rb
@@ -11,7 +11,7 @@ module Primer
         @page = page
       end
 
-      def resize(width:, height:)
+      def resize(width: viewport_width, height: viewport_height)
         if firefox?
           page.driver.browser.manage.window.resize_to(width, height)
         elsif chrome?
@@ -26,6 +26,14 @@ module Primer
         elsif chrome?
           page.driver.browser.viewport_size
         end
+      end
+
+      def viewport_width
+        viewport_size[0]
+      end
+
+      def viewport_height
+        viewport_size[1]
       end
     end
 


### PR DESCRIPTION
⚠️ ~~**This PR is based on #243** - please review/merge that PR first.~~
⚠️ **This PR requires an upstream enhancement to Cuprite** in order for tests to run green - https://github.com/rubycdp/cuprite/pull/291 (and optionally https://github.com/rubycdp/ferrum/pull/524)

### What are you trying to accomplish?

Fix Danger Dialog scroll behaviour when the dialog contains a form + **verify behaviour is correct with system test**.

### Screenshots

See #243 

### Integration

N/A

#### List the issues that this change affects.

https://community.openproject.org/wp/61546

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation
- [X] Added/updated previews (Lookbook)
- [X] Tested in Chrome
- [X] Tested in Firefox
- [X] Tested in Safari
- [ ] Tested in Edge
