### PR TITLE
[#61347] Danger and Feedback Dialogs have broken ARIA describedby attribute value

### DIFF
--- a/.changeset/polite-pets-shop.md
+++ b/.changeset/polite-pets-shop.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Fix broken FeedbackDialog aria-describedby value - was referencing non-existent id.

--- a/.changeset/twelve-bags-dance.md
+++ b/.changeset/twelve-bags-dance.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Fix broken DangerDialog aria-describedby value - was referencing non-existent id.

--- a/app/components/primer/open_project/danger_dialog.rb
+++ b/app/components/primer/open_project/danger_dialog.rb
@@ -20,6 +20,7 @@ module Primer
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :confirmation_message, lambda { |icon_arguments: {}, **system_arguments|
         system_arguments[:border] = false
+        system_arguments[:id] = "#{dialog_id}-description"
 
         icon_arguments[:icon] ||= :"alert"
         icon_arguments[:color] ||= :danger

--- a/app/components/primer/open_project/feedback_dialog.rb
+++ b/app/components/primer/open_project/feedback_dialog.rb
@@ -16,6 +16,8 @@ module Primer
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :feedback_message, lambda { |icon_arguments: {}, **system_arguments|
         system_arguments[:border] = false
+        system_arguments[:id] = "#{@system_arguments[:id]}-description"
+
         Primer::OpenProject::FeedbackMessage.new(icon_arguments: icon_arguments, **system_arguments)
       }
 

--- a/test/components/primer/open_project/danger_dialog_test.rb
+++ b/test/components/primer/open_project/danger_dialog_test.rb
@@ -30,6 +30,18 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
     assert_selector("dialog[aria-modal=true]")
   end
 
+  def test_renders_aria_describedby
+    render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger action")) do |dialog|
+      dialog.with_confirmation_message do |message|
+        message.with_heading(tag: :h2) { "Danger" }
+      end
+    end
+
+    dialog_labelledby_id = page.find_css("dialog").first.attributes["aria-describedby"].value
+    feedback_message_id = page.find_css(".FeedbackMessage").first.attributes["id"].value
+    assert_equal dialog_labelledby_id, feedback_message_id
+  end
+
   def test_renders_default_button_text
     render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger action")) do |dialog|
       dialog.with_confirmation_message do |message|

--- a/test/components/primer/open_project/feedback_dialog_test.rb
+++ b/test/components/primer/open_project/feedback_dialog_test.rb
@@ -19,6 +19,18 @@ class PrimerOpenProjectFeedbackDialogTest < Minitest::Test
     end
   end
 
+  def test_renders_aria_describedby
+    render_inline(Primer::OpenProject::FeedbackDialog.new(title: "Success message")) do |dialog|
+      dialog.with_feedback_message do |message|
+        message.with_heading(tag: :h2) { "Success" }
+      end
+    end
+
+    dialog_labelledby_id = page.find_css("dialog").first.attributes["aria-describedby"].value
+    feedback_message_id = page.find_css(".FeedbackMessage").first.attributes["id"].value
+    assert_equal dialog_labelledby_id, feedback_message_id
+  end
+
   def test_renders_additional_details
     render_inline(Primer::OpenProject::FeedbackDialog.new(title: "Success message")) do |dialog|
       dialog.with_feedback_message do |message|


### PR DESCRIPTION
### What are you trying to accomplish?

Fix broken ARIA `describedby` attribute value for the Danger and Feedback Dialogs.

### Screenshots

**Before**

<img width="1021" alt="Screenshot 2025-02-20 at 09 35 16" src="https://github.com/user-attachments/assets/2a02df08-a6cd-473e-87e5-3c217cd2d263" />

**After**

<img width="1024" alt="Screenshot 2025-02-20 at 09 37 35" src="https://github.com/user-attachments/assets/d67a5c2f-298a-4e05-be36-a40e420b9c11" />


### Integration

N/A

#### List the issues that this change affects.

https://community.openproject.org/wp/61347

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [X] Tested in Chrome
- [X] Tested in Firefox
- [X] Tested in Safari
- [ ] Tested in Edge
