### PR TITLE
[#61630] Danger Dialog should use `alertdialog` ARIA role

### DIFF
--- a/.changeset/gold-clouds-explain.md
+++ b/.changeset/gold-clouds-explain.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+DangerDialog now uses the "alertdialog" ARIA role

--- a/.playwright/screenshots/snapshots.test.ts-snapshots/primer/open_project/danger_dialog/default/aria-snapshot--after-interaction.yml
+++ b/.playwright/screenshots/snapshots.test.ts-snapshots/primer/open_project/danger_dialog/default/aria-snapshot--after-interaction.yml
@@ -1,5 +1,5 @@
 - button "Click me"
-- dialog "Delete dialog":
+- alertdialog "Delete dialog":
   - heading "Delete dialog" [level=1]
   - button "Close"
   - heading "Delete this item?" [level=2]

--- a/.playwright/screenshots/snapshots.test.ts-snapshots/primer/open_project/danger_dialog/with_confirmation_check_box/aria-snapshot--after-interaction.yml
+++ b/.playwright/screenshots/snapshots.test.ts-snapshots/primer/open_project/danger_dialog/with_confirmation_check_box/aria-snapshot--after-interaction.yml
@@ -1,5 +1,5 @@
 - button "Click me"
-- dialog "Delete dialog":
+- alertdialog "Delete dialog":
   - heading "Delete dialog" [level=1]
   - button "Close"
   - heading "Permanently delete this item?" [level=2]

--- a/app/components/primer/open_project/danger_dialog.rb
+++ b/app/components/primer/open_project/danger_dialog.rb
@@ -82,12 +82,15 @@ module Primer
         @confirm_button_text = confirm_button_text
         @cancel_button_text = cancel_button_text
 
+        deny_single_argument(:role, "`role` will always be set to `alertdialog`.", **system_arguments)
+
         @system_arguments = system_arguments
         @system_arguments[:id] = @dialog_id
         @system_arguments[:classes] = class_names(
           system_arguments[:classes],
           "DangerDialog"
         )
+        @system_arguments[:role] = "alertdialog"
 
         @dialog = Primer::Alpha::Dialog.new(title: title, subtitle: nil, visually_hide_title: true, **@system_arguments)
       end

--- a/app/components/primer/open_project/danger_dialog_form_helper.ts
+++ b/app/components/primer/open_project/danger_dialog_form_helper.ts
@@ -22,9 +22,6 @@ class DangerDialogFormHelperElement extends HTMLElement {
   }
 
   #reset(): void {
-    if (this.checkbox) {
-      this.checkbox.disabled = false
-    }
     this.toggle()
   }
 }

--- a/test/components/primer/open_project/danger_dialog_test.rb
+++ b/test/components/primer/open_project/danger_dialog_test.rb
@@ -19,6 +19,17 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
     end
   end
 
+  def test_renders_alertdialog_role
+    render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger action")) do |dialog|
+      dialog.with_confirmation_message do |message|
+        message.with_heading(tag: :h2) { "Danger" }
+      end
+    end
+
+    assert_selector("dialog[role=alertdialog]")
+    assert_selector("dialog[aria-modal=true]")
+  end
+
   def test_renders_default_button_text
     render_inline(Primer::OpenProject::DangerDialog.new(title: "Danger action")) do |dialog|
       dialog.with_confirmation_message do |message|
@@ -95,6 +106,14 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
       assert_selector(".Overlay-footer .Button", text: "Nah")
       assert_selector(".Overlay-footer .Button", text: "Do it FOREVER!")
     end
+  end
+
+  def test_does_not_render_if_role_argument_provided
+    error = assert_raises(ArgumentError) do
+      render_inline(Primer::OpenProject::DangerDialog.new(title: "Invalid action", role: "button"))
+    end
+
+    assert_equal "`role` is an invalid argument. `role` will always be set to `alertdialog`.", error.message
   end
 
   def test_does_not_render_if_no_confirmation_message_provided


### PR DESCRIPTION
### What are you trying to accomplish?

Improve semantics for users of assistive technology.

### Screenshots

No visual changes

### Integration

No.

#### List the issues that this change affects.

https://community.openproject.org/wp/61630

#### Risk Assessment

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

Danger dialogs (both the confirmation and default, warning variant) clearly adhere to the alert dialog pattern:

> The alertdialog role is to be used on modal alert dialogs that
> interrupt a user's workflow to communicate an important message and
> require a response.

See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role

### Anything you want to highlight for special attention from reviewers?

N/A

### Accessibility

- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.


### Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [X] Tested in Chrome
- [X] Tested in Firefox
- [X] Tested in Safari
- [ ] Tested in Edge
