### PR TITLE
Fix `merge-upstream` script for macOS users

### DIFF
--- a/script/merge-upstream
+++ b/script/merge-upstream
@@ -20,4 +20,4 @@ git checkout -b bump/primer-upstream
 git reset --hard origin/main
 git merge bump/primer-upstream-ref
 
-find .changeset/ -name "*.md" -exec $SED -i "s/\@primer\/view-components/\@openproject\/primer-view-components/g" {} +
+find .changeset/ -name "*.md" -exec $SED -i '' "s/\@primer\/view-components/\@openproject\/primer-view-components/g" {} +


### PR DESCRIPTION
FreeBSD-based implementations of `sed` require an empty argument with the `-i` flag.

See SO comment: https://unix.stackexchange.com/a/36805