### PR TITLE
Allow ActionMenu as sidepanel section action

### DIFF
--- a/.changeset/strong-months-carry.md
+++ b/.changeset/strong-months-carry.md
@@ -1,0 +1,5 @@
+---
+"@openproject/primer-view-components": minor
+---
+
+Allow ActionMenu as sidepanel section action

--- a/app/components/primer/open_project/side_panel/section.rb
+++ b/app/components/primer/open_project/side_panel/section.rb
@@ -21,7 +21,18 @@ module Primer
           icon: lambda { |**system_arguments, &block|
             system_arguments[:scheme] ||= :invisible
             Primer::Beta::IconButton.new(**system_arguments, &block)
-          }
+          },
+          menu: lambda { |**system_arguments, &block|
+            deny_tag_argument(**system_arguments)
+
+            button_arguments = system_arguments.delete(:button_arguments) || {}
+            button_arguments[:scheme] ||= :invisible
+            raise ArgumentError.new("button_arguments must contain an icon:") if button_arguments[:icon].blank?
+
+            Primer::Alpha::ActionMenu.new(**system_arguments).tap do |menu|
+              menu.with_show_button(**button_arguments)
+            end
+          },
         }
 
         renders_one :description, lambda { |**system_arguments, &block|

--- a/previews/primer/open_project/side_panel_preview.rb
+++ b/previews/primer/open_project/side_panel_preview.rb
@@ -33,6 +33,10 @@ module Primer
       # @label With custom component
       def with_component
       end
+
+      # @label With action menu
+      def with_action_menu
+      end
     end
   end
 end

--- a/previews/primer/open_project/side_panel_preview/with_action_menu.html.erb
+++ b/previews/primer/open_project/side_panel_preview/with_action_menu.html.erb
@@ -1,0 +1,37 @@
+<%=
+  clazz = Class.new(ViewComponent::Base) do
+    def self.name
+      "CustomComponent"
+    end
+
+    def call
+      render(Primer::OpenProject::SidePanel::Section.new) do |section|
+        section.with_title { "My custom component" }
+        section.with_action_menu(
+          anchor_align: :end,
+          button_arguments: { icon: :gear, 'aria-label': 'Edit' }
+        ) do |menu|
+          menu.with_item(label: "Subitem 1") do |item|
+            item.with_leading_visual_icon(icon: :paste)
+          end
+          menu.with_item(label: "Subitem 2") do |item|
+            item.with_leading_visual_icon(icon: :log)
+          end
+        end
+
+        "Section content"
+      end
+    end
+  end
+
+  render(Primer::Alpha::Layout.new) do |component|
+    component.with_main do
+      "Main content"
+    end
+    component.with_sidebar(row_placement: :start, col_placement: :end) do
+      render(Primer::OpenProject::SidePanel.new) do |panel|
+        panel.with_section(clazz.new)
+      end
+    end
+  end
+%>

--- a/test/components/primer/open_project/side_panel_test.rb
+++ b/test/components/primer/open_project/side_panel_test.rb
@@ -62,6 +62,24 @@ class PrimerOpenProjectSidePanelTest < Minitest::Test
     assert_text("custom content")
   end
 
+  def test_renders_action_menu
+    render_inline(Primer::OpenProject::SidePanel.new) do |component|
+      component.with_section do |section|
+        section.with_title { "Section with menu" }
+        section.with_action_menu(button_arguments: { icon: :pencil, "aria-label": "Menu" }) do |menu|
+          menu.with_item { "Menu item" }
+        end
+
+        "Section content"
+      end
+    end
+
+    assert_selector(".SidePanel")
+    assert_selector(".SidePanel section", count: 1)
+    assert_selector(".SidePanel action-menu")
+    assert_selector("li.ActionListItem", count: 1)
+  end
+
   def test_no_renders_empty_section
     render_inline(Primer::OpenProject::SidePanel.new) do |component|
       component.with_section do |section|


### PR DESCRIPTION
https://community.openproject.org/work_packages/61788

### What are you trying to accomplish?
Allow ActionMenu as sidepanel section action

### Screenshots
<img width="397" alt="Bildschirmfoto 2025-02-26 um 11 11 06" src="https://github.com/user-attachments/assets/cd27231e-f6a3-4ca0-9d06-0602870bad7f" />


#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
