### PR TITLE
Dialogs close when moving mouse outside of it

### DIFF
--- a/.changeset/no-close-dialog-with-form.md
+++ b/.changeset/no-close-dialog-with-form.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Do not close dialogs when clicking on the backdrop if the dialog contains a form

--- a/.changeset/no-close-dialog-with-form.md
+++ b/.changeset/no-close-dialog-with-form.md
@@ -1,5 +1,5 @@
 ---
-'@primer/view-components': patch
+'@openproject/primer-view-components': patch
 ---
 
 Do not close dialogs when clicking on the backdrop if the dialog contains a form

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -111,6 +111,9 @@ export class DialogHelperElement extends HTMLElement {
     // The click target _must_ be the dialog element itself, and not elements underneath or inside.
     if (target !== dialog || !dialog?.open) return
 
+    // If the dialog contains a form, do not close the dialog when clicking outside of the dialog
+    if (dialog.querySelector('form')) return
+
     const rect = dialog.getBoundingClientRect()
     const clickWasInsideDialog =
       rect.top <= event.clientY &&

--- a/test/system/alpha/dialog_test.rb
+++ b/test/system/alpha/dialog_test.rb
@@ -89,6 +89,15 @@ module Alpha
       refute_selector "dialog[open]"
     end
 
+    def test_outside_click_does_not_close_dialog_with_form
+      visit_preview(:with_form)
+
+      click_button("Show Dialog")
+      mouse.click(x: 0, y: 0)
+
+      assert_selector "dialog[open]"
+    end
+
     def test_outside_menu_click_does_not_close_dialog
       visit_preview(:with_auto_complete)
 


### PR DESCRIPTION
### What are you trying to accomplish?
Do not close dialog when clicking on the backdrop when it contains a form


#### List the issues that this change affects.

Closes 
https://community.openproject.org/work_packages/62076
https://community.openproject.org/work_packages/62041


### What approach did you choose and why?
Cherry-pick from upstream

