### PR TITLE
[62747]  CollapsibleHeader example not working in Lookbook

### DIFF
--- a/.changeset/spotty-islands-battle.md
+++ b/.changeset/spotty-islands-battle.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+CollapsibleHeader checks for surrounding Box only when being connected

--- a/app/components/primer/open_project/border_box/collapsible_header.ts
+++ b/app/components/primer/open_project/border_box/collapsible_header.ts
@@ -9,16 +9,11 @@ class CollapsibleHeaderElement extends HTMLElement {
   @attr collapsed: string
   private _collapsed: boolean
 
-  // eslint-disable-next-line custom-elements/no-constructor
-  constructor() {
-    super()
-
+  connectedCallback() {
     if (!this.closest('.Box')) {
       throw new Error('No surrounding BorderBox found')
     }
-  }
 
-  connectedCallback() {
     if (this.collapsed === 'true') {
       this._collapsed = true
       this.hideAll()


### PR DESCRIPTION



### What are you trying to accomplish?
Move the check to the connectedCallback instead of the constructor because the Box might not be rendered before that.

This is an attempt to close https://community.openproject.org/projects/openproject/work_packages/62747/activity

Since I can't reproduce that locally, it is more an educated guess then anything else