### PR TITLE
Safeguard JS targets for CollapsibleHeaders

### DIFF
--- a/.changeset/lazy-needles-float.md
+++ b/.changeset/lazy-needles-float.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Safeguard CollapsibleHeader class toggling

--- a/app/components/primer/open_project/border_box/collapsible_header.rb
+++ b/app/components/primer/open_project/border_box/collapsible_header.rb
@@ -3,9 +3,8 @@
 module Primer
   module OpenProject
     module BorderBox
-      # Add a general description of component here
-      # Add additional usage considerations or best practices that may aid the user to use the component correctly.
-      # @accessibility Add any accessibility considerations
+      # A component to be used inside Primer::Beta::BorderBox.
+      # It will toggle the visibility of the complete Box body
       class CollapsibleHeader < Primer::Component
         status :open_project
 

--- a/app/components/primer/open_project/border_box/collapsible_header.ts
+++ b/app/components/primer/open_project/border_box/collapsible_header.ts
@@ -4,7 +4,7 @@ import {attr, controller, target} from '@github/catalyst'
 class CollapsibleHeaderElement extends HTMLElement {
   @target arrowDown: HTMLElement
   @target arrowUp: HTMLElement
-  @target description: HTMLElement
+  @target description: HTMLElement | undefined
 
   @attr collapsed: string
   private _collapsed: boolean
@@ -33,23 +33,19 @@ class CollapsibleHeaderElement extends HTMLElement {
   }
 
   private hideAll() {
-    this.arrowDown.classList.remove('d-none')
-    this.arrowUp.classList.add('d-none')
+    this.arrowDown?.classList.remove('d-none')
+    this.arrowUp?.classList.add('d-none')
 
-    if (this.description !== undefined) {
-      this.description.classList.add('d-none')
-    }
+    this.description?.classList.add('d-none')
 
     this.classList.add('CollapsibleHeader--collapsed')
   }
 
   private expandAll() {
-    this.arrowDown.classList.add('d-none')
-    this.arrowUp.classList.remove('d-none')
+    this.arrowDown?.classList.add('d-none')
+    this.arrowUp?.classList.remove('d-none')
 
-    if (this.description !== undefined) {
-      this.description.classList.remove('d-none')
-    }
+    this.description?.classList.remove('d-none')
 
     this.classList.remove('CollapsibleHeader--collapsed')
   }

--- a/test/components/primer/open_project/border_box/collapsible_header_test.rb
+++ b/test/components/primer/open_project/border_box/collapsible_header_test.rb
@@ -23,7 +23,7 @@ class Primer::OpenProject::BorderBox::CollapsibleHeaderTest < Minitest::Test
 
   def test_does_not_render_with_empty_title
     err = assert_raises ArgumentError do
-      render_inline(render_inline(Primer::OpenProject::BorderBox::CollapsibleHeader.new(title: "", box: "Some component")))
+      render_inline(Primer::OpenProject::BorderBox::CollapsibleHeader.new(title: "", box: "Some component"))
     end
 
     assert_equal "Title must be present", err.message
@@ -31,7 +31,7 @@ class Primer::OpenProject::BorderBox::CollapsibleHeaderTest < Minitest::Test
 
   def test_does_not_render_without_valid_box
     err = assert_raises ArgumentError do
-      render_inline(render_inline(Primer::OpenProject::BorderBox::CollapsibleHeader.new(title: "Test title", box: "Some component")))
+      render_inline(Primer::OpenProject::BorderBox::CollapsibleHeader.new(title: "Test title", box: "Some component"))
     end
 
     assert_equal "This component must be called inside the header of a `Primer::Beta::BorderBox`", err.message
@@ -39,7 +39,7 @@ class Primer::OpenProject::BorderBox::CollapsibleHeaderTest < Minitest::Test
 
   def test_does_not_render_with_empty_description
     err = assert_raises ArgumentError do
-      render_inline(render_inline(Primer::OpenProject::BorderBox::CollapsibleHeader.new(title: "Test title", box: "Some component", description: "")))
+      render_inline(Primer::OpenProject::BorderBox::CollapsibleHeader.new(title: "Test title", box: "Some component", description: ""))
     end
 
     assert_equal "Description cannot be a blank string", err.message
@@ -47,7 +47,7 @@ class Primer::OpenProject::BorderBox::CollapsibleHeaderTest < Minitest::Test
 
   def test_does_not_render_with_empty_count
     err = assert_raises ArgumentError do
-      render_inline(render_inline(Primer::OpenProject::BorderBox::CollapsibleHeader.new(title: "Test title", box: "Some component", count: "")))
+      render_inline(Primer::OpenProject::BorderBox::CollapsibleHeader.new(title: "Test title", box: "Some component", count: ""))
     end
 
     assert_equal "Count cannot be a blank string", err.message


### PR DESCRIPTION
### What are you trying to accomplish?
When accessing ~https://qa.openproject-edge.com/lookbook/inspect/primer/open_project/border_box/collapsible_header/playground~ https://qa.openproject-edge.com/lookbook/inspect/primer/open_project/border_box/collapsible_header/collapsed, you can see an error on the console:


<img width="722" alt="Bildschirmfoto 2025-04-03 um 15 40 02" src="https://github.com/user-attachments/assets/6825e330-5e06-4d3a-9638-f1e159c07baf" />


