### PR TITLE
[61779] Form input: introduce a smaller input size for date/time

### DIFF
--- a/.changeset/eleven-cooks-attend.md
+++ b/.changeset/eleven-cooks-attend.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Add `xsmall` to the inpu_witdh options

--- a/app/components/primer/alpha/select.rb
+++ b/app/components/primer/alpha/select.rb
@@ -21,6 +21,7 @@ module Primer
       #
       # @macro form_size_arguments
       # @macro form_input_arguments
+      # @macro form_input_width_arguments
       #
       # @param multiple [Boolean] If set to true, the selection will allow multiple choices.
       # @param include_blank [Boolean, String] If set to true, an empty option will be created. If set to a string, the string will be used as the option's content and the value will be empty.

--- a/app/components/primer/alpha/text_area.rb
+++ b/app/components/primer/alpha/text_area.rb
@@ -19,6 +19,7 @@ module Primer
       #
       # @macro form_full_width_arguments
       # @macro form_input_arguments
+      # @macro form_input_width_arguments
     end
   end
 end

--- a/app/components/primer/alpha/text_field.pcss
+++ b/app/components/primer/alpha/text_field.pcss
@@ -239,6 +239,10 @@
     width: auto;
   }
 
+  &.FormControl-input-width--xsmall {
+    max-width: min(144px, 100vw - 2rem);
+  }
+
   &.FormControl-input-width--small {
     max-width: min(256px, 100vw - 2rem);
   }
@@ -252,7 +256,7 @@
   }
 
   &.FormControl-input-width--xlarge {
-    max-width: min(640px, 100vw - 2rem);
+    max-width: min(680px, 100vw - 2rem);
   }
 
   &.FormControl-input-width--xxlarge {

--- a/app/components/primer/alpha/text_field.rb
+++ b/app/components/primer/alpha/text_field.rb
@@ -20,6 +20,7 @@ module Primer
       # @macro form_size_arguments
       # @macro form_full_width_arguments
       # @macro form_input_arguments
+      # @macro form_input_width_arguments
       #
       # @param placeholder [String] Placeholder text.
       # @param inset [Boolean] If `true`, renders the input in a visually inset state.

--- a/app/components/primer/open_project/input_group.pcss
+++ b/app/components/primer/open_project/input_group.pcss
@@ -3,6 +3,10 @@
         width: auto;
     }
 
+    &.InputGroup-input-width--xsmall {
+        max-width: min(144px, 100vw - 2rem);
+    }
+
     &.InputGroup-input-width--small {
         max-width: min(256px, 100vw - 2rem);
     }
@@ -16,7 +20,7 @@
     }
 
     &.InputGroup-input-width--xlarge {
-        max-width: min(640px, 100vw - 2rem);
+        max-width: min(680px, 100vw - 2rem);
     }
 
     &.InputGroup-input-width--xxlarge {

--- a/app/components/primer/open_project/input_group.rb
+++ b/app/components/primer/open_project/input_group.rb
@@ -9,6 +9,7 @@ module Primer
       DEFAULT_INPUT_WIDTH = :auto
       INPUT_WIDTH_MAPPINGS = {
         DEFAULT_INPUT_WIDTH => "InputGroup-input-width--auto",
+        :xsmall => "InputGroup-input-width--xsmall",
         :small => "InputGroup-input-width--small",
         :medium => "InputGroup-input-width--medium",
         :large => "InputGroup-input-width--large",

--- a/app/lib/primer/forms/dsl/input.rb
+++ b/app/lib/primer/forms/dsl/input.rb
@@ -33,6 +33,9 @@ module Primer
         # @!macro [new] form_full_width_arguments
         #   @param full_width [Boolean] When set to `true`, the field will take up all the horizontal space allowed by its container. Defaults to `true`.
 
+        # @!macro [new] form_input_width_arguments
+        #   @param input_width [Symbol] The width of the field. <%= one_of(Primer::Forms::Dsl::Input::INPUT_WIDTH_OPTIONS) %>
+
         # @!macro [new] form_system_arguments
         #   @param system_arguments [Hash] A hash of attributes passed to the underlying Rails builder methods. These options may mean something special depending on the type of input, otherwise they are emitted as HTML attributes. See the [Rails documentation](https://guides.rubyonrails.org/form_helpers.html) for more information. In addition, the usual Primer utility arguments are accepted in system arguments. For example, passing `mt: 2` will add the `mt-2` class to the input. See the Primer system arguments docs for details.
 
@@ -48,6 +51,7 @@ module Primer
         DEFAULT_INPUT_WIDTH = :auto
         INPUT_WIDTH_MAPPINGS = {
           DEFAULT_INPUT_WIDTH => "FormControl-input-width--auto",
+          :xsmall => "FormControl-input-width--xsmall",
           :small => "FormControl-input-width--small",
           :medium => "FormControl-input-width--medium",
           :large => "FormControl-input-width--large",

--- a/previews/primer/alpha/select_preview.rb
+++ b/previews/primer/alpha/select_preview.rb
@@ -18,7 +18,7 @@ module Primer
       # @param disabled toggle
       # @param invalid toggle
       # @param validation_message text
-      # @param input_width [Symbol] select [auto, small, medium, large, xlarge, xxlarge]
+      # @param input_width [Symbol] select [auto, xsmall, small, medium, large, xlarge, xxlarge]
       def playground(
         name: "my-select-list",
         id: "my-select-list",

--- a/previews/primer/alpha/text_area_preview.rb
+++ b/previews/primer/alpha/text_area_preview.rb
@@ -16,7 +16,7 @@ module Primer
       # @param disabled toggle
       # @param invalid toggle
       # @param validation_message text
-      # @param input_width [Symbol] select [auto, small, medium, large, xlarge, xxlarge]
+      # @param input_width [Symbol] select [auto, xsmall, small, medium, large, xlarge, xxlarge]
       def playground(
         name: "my-text-area",
         id: "my-text-area",

--- a/previews/primer/alpha/text_field_preview.rb
+++ b/previews/primer/alpha/text_field_preview.rb
@@ -24,7 +24,7 @@ module Primer
       # @param monospace toggle
       # @param leading_visual_icon octicon
       # @param leading_spinner toggle
-      # @param input_width [Symbol] select [auto, small, medium, large, xlarge, xxlarge]
+      # @param input_width [Symbol] select [auto, xsmall, small, medium, large, xlarge, xxlarge]
       def playground(
         name: "my-text-field",
         id: "my-text-field",
@@ -200,7 +200,7 @@ module Primer
       end
 
       # @label With trailing label
-      # @snapshot 
+      # @snapshot
       def with_trailing_label
         render(Primer::Alpha::TextField.new(trailing_visual: { label: { text: "Hello" } }, name: "my-text-field-15", label: "My text field"))
       end
@@ -219,7 +219,7 @@ module Primer
       #
       # @!endgroup
 
-      # @!group Auto check 
+      # @!group Auto check
       #
       # @label Auto check request ok
       def with_auto_check_ok

--- a/previews/primer/forms_preview/custom_width_fields_form.html.erb
+++ b/previews/primer/forms_preview/custom_width_fields_form.html.erb
@@ -28,6 +28,15 @@
         caption: "What else do you need?",
         input_width: :small
       )
+
+      f.text_field(
+        name: :hours,
+        label: "hours",
+        type: :number,
+        required: true,
+        trailing_visual: { text: { text: "min" } },
+        input_width: :xsmall
+      )
     end
   end
 %>

--- a/previews/primer/open_project/input_group_preview.rb
+++ b/previews/primer/open_project/input_group_preview.rb
@@ -21,7 +21,7 @@ module Primer
       # @param value [String]
       # @param visually_hide_label toggle
       # @param readonly toggle
-      # @param input_width [Symbol] select [auto, small, medium, large, xlarge, xxlarge]
+      # @param input_width [Symbol] select [auto, xsmall, small, medium, large, xlarge, xxlarge]
       # @param caption [String]
       def playground(
         trailing_action: :clipboardCopy,

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -180,6 +180,7 @@ class ComponentSpecificSelectorsTest < Minitest::Test
       ".TimelineItem--condensed .TimelineItem-badge"
     ],
     Primer::OpenProject::InputGroup => [
+      ".InputGroup-input-width--xsmall",
       ".InputGroup-input-width--large",
       ".InputGroup-input-width--xlarge",
       ".InputGroup-input-width--xxlarge",

--- a/test/lib/primer/forms_test.rb
+++ b/test/lib/primer/forms_test.rb
@@ -36,11 +36,21 @@ class Primer::FormsTest < Minitest::Test
           caption: "What else do you need?",
           input_width: :large
         )
+
+        f.text_field(
+          name: :hours,
+          label: "hours",
+          type: :number,
+          required: true,
+          trailing_visual: { text: { text: "min" } },
+          input_width: :xsmall
+        )
       end
     end
 
     render_inline Primer::FormTestComponent.new(form_class: custom_width_form)
 
+    assert_selector "div.FormControl-input-width--xsmall"
     assert_selector "div.FormControl-input-width--medium"
     assert_selector "div.FormControl-input-width--small"
     assert_selector "div.FormControl-input-width--large"


### PR DESCRIPTION
### What are you trying to accomplish?
* Introduce xsmall for input_width
* Change xlarge from 640 to 680

### Screenshots
<img width="425" alt="Bildschirmfoto 2025-04-07 um 11 18 47" src="https://github.com/user-attachments/assets/87511f66-f4d2-43f5-abbe-ea1ce387fe76" />

