### PR TITLE
[61631] Primer Dialog close button ARIA label is not localised

### DIFF
--- a/.changeset/upset-boats-smoke.md
+++ b/.changeset/upset-boats-smoke.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Provide a default string for the close button on DangerDialog and FeedbackDialog

--- a/.playwright/screenshots/snapshots.test.ts-snapshots/primer/open_project/danger_dialog/default/aria-snapshot--after-interaction.yml
+++ b/.playwright/screenshots/snapshots.test.ts-snapshots/primer/open_project/danger_dialog/default/aria-snapshot--after-interaction.yml
@@ -1,7 +1,7 @@
 - button "Click me"
 - alertdialog "Delete dialog":
   - heading "Delete dialog" [level=1]
-  - button "Close"
+  - 'button "Translation missing: en.button_close"'
   - heading "Delete this item?" [level=2]
   - paragraph: Do you want to continue?
   - 'button "Translation missing: en.button_cancel"'

--- a/.playwright/screenshots/snapshots.test.ts-snapshots/primer/open_project/danger_dialog/with_confirmation_check_box/aria-snapshot--after-interaction.yml
+++ b/.playwright/screenshots/snapshots.test.ts-snapshots/primer/open_project/danger_dialog/with_confirmation_check_box/aria-snapshot--after-interaction.yml
@@ -1,7 +1,7 @@
 - button "Click me"
 - alertdialog "Delete dialog":
   - heading "Delete dialog" [level=1]
-  - button "Close"
+  - 'button "Translation missing: en.button_close"'
   - heading "Permanently delete this item?" [level=2]
   - paragraph: This action is not reversible. Please proceed with caution.
   - checkbox "I understand that this deletion cannot be reversed": "1"

--- a/.playwright/screenshots/snapshots.test.ts-snapshots/primer/open_project/feedback_dialog/default/aria-snapshot--after-interaction.yml
+++ b/.playwright/screenshots/snapshots.test.ts-snapshots/primer/open_project/feedback_dialog/default/aria-snapshot--after-interaction.yml
@@ -1,7 +1,7 @@
 - button "Click me"
 - dialog "Success dialog":
   - heading "Success dialog" [level=1]
-  - button "Close"
+  - 'button "Translation missing: en.button_close"'
   - heading "Success" [level=2]
   - paragraph: Great! Everything worked well.
   - 'button "Translation missing: en.button_close"'

--- a/app/components/primer/open_project/danger_dialog.html.erb
+++ b/app/components/primer/open_project/danger_dialog.html.erb
@@ -1,4 +1,8 @@
 <%= render @dialog do |dialog| %>
+  <% unless header.present? %>
+    <% dialog.with_header(close_label: I18n.t("button_close")) %>
+  <% end %>
+
   <danger-dialog-form-helper>
     <%= render(@form_wrapper) do %>
       <scrollable-region data-labelled-by="<%= labelledby %>">

--- a/app/components/primer/open_project/feedback_dialog.html.erb
+++ b/app/components/primer/open_project/feedback_dialog.html.erb
@@ -1,10 +1,15 @@
 <%= render @dialog do |dialog| %>
+  <% unless header.present? %>
+    <% dialog.with_header(close_label: I18n.t("button_close")) %>
+  <% end %>
+
   <% dialog.with_body do %>
     <%= feedback_message %>
     <% if additional_details.present? %>
       <%= additional_details %>
     <% end %>
   <% end %>
+
   <% dialog.with_footer do %>
     <% if footer.present? %>
       <%= footer %>


### PR DESCRIPTION
### What are you trying to accomplish?

Provide a default I18n string for the close button in FeedbackDialog and DangerDialog

#### List the issues that this change affects.
https://community.openproject.org/projects/design-system/work_packages/61631/activity

