### PR TITLE
[60332] Implement proper mobile behaviour for Sub Header component (OP Primer)

### DIFF
--- a/.changeset/fuzzy-ravens-speak.md
+++ b/.changeset/fuzzy-ravens-speak.md
@@ -2,4 +2,4 @@
 '@openproject/primer-view-components': minor
 ---
 
-Improve mobile support for SubHeader
+Improve mobile support for SubHeader by requiring a leading icon for each action. Further, the support for custom action buttons was removed.

--- a/.changeset/fuzzy-ravens-speak.md
+++ b/.changeset/fuzzy-ravens-speak.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': minor
+---
+
+Improve mobile support for SubHeader

--- a/app/components/primer/open_project/page_header.rb
+++ b/app/components/primer/open_project/page_header.rb
@@ -150,7 +150,7 @@ module Primer
             @mobile_segmented_control = Primer::Alpha::SegmentedControl.new(**system_arguments,
                                                                             **mobile_args,
                                                                             mr: 2,
-                                                                            display: %i[flex none])
+                                                                            display: MOBILE_ACTIONS_DISPLAY)
             @mobile_segmented_control_block = block
 
             Primer::Alpha::SegmentedControl.new(**system_arguments)

--- a/app/components/primer/open_project/sub_header.html.erb
+++ b/app/components/primer/open_project/sub_header.html.erb
@@ -8,6 +8,8 @@
     <% end if filter_input.present? %>
     <%= render @mobile_filter_trigger if @mobile_filter_trigger.present? %>
     <%= filter_button %>
+
+    <%= segmented_control %>
   </div>
   <div class="SubHeader-middlePane" data-targets="<%= HIDDEN_FILTER_TARGET_SELECTOR %>">
     <%= text %>

--- a/app/components/primer/open_project/sub_header.html.erb
+++ b/app/components/primer/open_project/sub_header.html.erb
@@ -6,7 +6,10 @@
         I18n.t("button_cancel")
       end if @mobile_filter_cancel.present? %>
     <% end if filter_input.present? %>
+
     <%= render @mobile_filter_trigger if @mobile_filter_trigger.present? %>
+
+    <%= render(@mobile_filter_button) if @mobile_filter_button.present? %>
     <%= filter_button %>
 
     <%= segmented_control %>
@@ -16,6 +19,7 @@
   </div>
   <div class="SubHeader-rightPane" data-targets="<%= HIDDEN_FILTER_TARGET_SELECTOR %>">
     <% actions.each do |action| %>
+      <%= render(@mobile_button) if @mobile_button.present? %>
       <%= action %>
     <% end %>
   </div>

--- a/app/components/primer/open_project/sub_header.html.erb
+++ b/app/components/primer/open_project/sub_header.html.erb
@@ -10,18 +10,22 @@
     <%= render @mobile_filter_trigger if @mobile_filter_trigger.present? %>
 
     <%= render(@mobile_filter_button) if @mobile_filter_button.present? %>
+
     <%= filter_button %>
 
     <%= segmented_control %>
+
     <% if @segmented_control_block.present? %>
       <%= render(@mobile_segmented_control) do |control| %>
         <% @segmented_control_block.call(control) %>
       <% end %>
     <% end %>
   </div>
+
   <div class="SubHeader-middlePane" data-targets="<%= HIDDEN_FILTER_TARGET_SELECTOR %>">
     <%= text %>
   </div>
+
   <div class="SubHeader-rightPane" data-targets="<%= HIDDEN_FILTER_TARGET_SELECTOR %>">
     <% actions.each do |action| %>
       <%= action %>
@@ -31,6 +35,7 @@
       <%= render(mobile_button) %>
     <% end unless @mobile_buttons.nil? %>
   </div>
+
   <% if bottom_pane_component.present? %>
     <div class="SubHeader-bottomPane">
       <%= bottom_pane_component %>

--- a/app/components/primer/open_project/sub_header.html.erb
+++ b/app/components/primer/open_project/sub_header.html.erb
@@ -31,9 +31,11 @@
       <%= action %>
     <% end %>
 
-    <% @mobile_buttons.each do |mobile_button| %>
-      <%= render(mobile_button) %>
-    <% end unless @mobile_buttons.nil? %>
+    <% @mobile_actions.each do |mobile_action| %>
+      <%= render(mobile_action[:component]) do |action| %>
+        <% mobile_action[:block].call(action) %>
+      <% end %>
+    <% end unless @mobile_actions.nil? %>
   </div>
 
   <% if bottom_pane_component.present? %>

--- a/app/components/primer/open_project/sub_header.html.erb
+++ b/app/components/primer/open_project/sub_header.html.erb
@@ -13,6 +13,11 @@
     <%= filter_button %>
 
     <%= segmented_control %>
+    <% if @segmented_control_block.present? %>
+      <%= render(@mobile_segmented_control) do |control| %>
+        <% @segmented_control_block.call(control) %>
+      <% end %>
+    <% end %>
   </div>
   <div class="SubHeader-middlePane" data-targets="<%= HIDDEN_FILTER_TARGET_SELECTOR %>">
     <%= text %>

--- a/app/components/primer/open_project/sub_header.html.erb
+++ b/app/components/primer/open_project/sub_header.html.erb
@@ -24,8 +24,11 @@
   </div>
   <div class="SubHeader-rightPane" data-targets="<%= HIDDEN_FILTER_TARGET_SELECTOR %>">
     <% actions.each do |action| %>
-      <%= render(@mobile_button) if @mobile_button.present? %>
       <%= action %>
+    <% end %>
+
+    <% @mobile_buttons.each do |mobile_button| %>
+      <%= render(mobile_button) %>
     <% end %>
   </div>
   <% if bottom_pane_component.present? %>

--- a/app/components/primer/open_project/sub_header.html.erb
+++ b/app/components/primer/open_project/sub_header.html.erb
@@ -29,7 +29,7 @@
 
     <% @mobile_buttons.each do |mobile_button| %>
       <%= render(mobile_button) %>
-    <% end %>
+    <% end unless @mobile_buttons.nil? %>
   </div>
   <% if bottom_pane_component.present? %>
     <div class="SubHeader-bottomPane">

--- a/app/components/primer/open_project/sub_header.pcss
+++ b/app/components/primer/open_project/sub_header.pcss
@@ -67,6 +67,12 @@
         grid-template-columns: auto 1fr auto;
     }
 
+    .SubHeader--emptyLeftPane .SubHeader-middlePane {
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+    }
+
     .SubHeader-middlePane {
         text-align: left;
     }

--- a/app/components/primer/open_project/sub_header.pcss
+++ b/app/components/primer/open_project/sub_header.pcss
@@ -53,3 +53,20 @@
 .SubHeader-filterInput_hiddenClearButton + button.FormControl-input-trailingAction {
   display: none;
 }
+
+@media (max-width: 543.98px) {
+    .SubHeader {
+        grid-template-areas: "left right" "middle middle" "bottom bottom";
+        grid-template-columns: 1fr auto;
+        grid-row-gap: var(--stack-gap-condensed);
+    }
+
+    .SubHeader--emptyLeftPane {
+        grid-template-areas: "middle middle right" "bottom bottom bottom";
+        grid-template-columns: auto 1fr auto;
+    }
+
+    .SubHeader-middlePane {
+        text-align: left;
+    }
+}

--- a/app/components/primer/open_project/sub_header.pcss
+++ b/app/components/primer/open_project/sub_header.pcss
@@ -33,7 +33,6 @@
     display: flex;
     align-items: center;
     width: 100%;
-    gap: 12px;
 
     /* Since the container is not full width (due to the grid around it)
      we want it to grow, and then be limited by the max-width of the "FormControl-input-width--xy" class */

--- a/app/components/primer/open_project/sub_header.pcss
+++ b/app/components/primer/open_project/sub_header.pcss
@@ -5,7 +5,7 @@
     grid-template-areas: "left middle right" "bottom bottom bottom";
     grid-template-columns: auto 1fr auto;
     align-items: center;
-    margin-bottom: 16px;
+    margin-bottom: var(--base-size-16);
 }
 
 .SubHeader--expandedSearch {
@@ -51,7 +51,7 @@
     gap: 8px;
 }
 
-.SubHeader-filterInput_hiddenClearButton + button.FormControl-input-trailingAction {
+.SubHeader-filterInput_hiddenClearButton + .FormControl-input-trailingAction {
   display: none;
 }
 

--- a/app/components/primer/open_project/sub_header.pcss
+++ b/app/components/primer/open_project/sub_header.pcss
@@ -58,7 +58,6 @@
     .SubHeader {
         grid-template-areas: "left right" "middle middle" "bottom bottom";
         grid-template-columns: 1fr auto;
-        grid-row-gap: var(--stack-gap-condensed);
     }
 
     .SubHeader--emptyLeftPane {
@@ -74,5 +73,9 @@
 
     .SubHeader-middlePane {
         text-align: left;
+    }
+
+    .SubHeader-middlePane:has(> *) {
+        margin-top: var(--stack-gap-normal);
     }
 }

--- a/app/components/primer/open_project/sub_header.pcss
+++ b/app/components/primer/open_project/sub_header.pcss
@@ -46,6 +46,7 @@
 
 .SubHeader-filterContainer {
     display: flex;
+    flex-basis: max-content;
     width: 100%;
     gap: 8px;
 }

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -124,17 +124,19 @@ module Primer
             kwargs[:mr] ||= 2
             kwargs[:icon] = leading_icon
 
+            kwargs[:aria] ||= merge_aria(
+              kwargs,
+              { aria: { label: mobile_label } }
+            )
+
             icon_args = kwargs.dup
             icon_args = set_as_hidden_filter_target(icon_args)
 
             if icon_only
               Primer::Beta::IconButton.new(**icon_args)
             else
-              @mobile_filter_button =  Primer::Beta::IconButton.new(aria: {
-                                                               label: mobile_label
-                                                             },
-                                                             display: MOBILE_ACTIONS_DISPLAY,
-                                                             **icon_args)
+              @mobile_filter_button =  Primer::Beta::IconButton.new(display: MOBILE_ACTIONS_DISPLAY,
+                                                                    **icon_args)
 
               Primer::OpenProject::SubHeader::Button.new(display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
             end

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -32,12 +32,14 @@ module Primer
               { aria: { label: label } }
             )
 
+            icon_args = kwargs.deep_dup
+
             if icon_only
-              Primer::Beta::IconButton.new(**kwargs)
+              Primer::Beta::IconButton.new(**icon_args)
             else
               @mobile_actions ||= []
               mobile_component =  Primer::Beta::IconButton.new(display: MOBILE_ACTIONS_DISPLAY,
-                                                               **kwargs)
+                                                               **icon_args)
               @mobile_actions.push({ component: mobile_component, block: block})
 
               Primer::OpenProject::SubHeader::Button.new(display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
@@ -141,7 +143,7 @@ module Primer
               { aria: { label: mobile_label } }
             )
 
-            icon_args = kwargs.dup
+            icon_args = kwargs.deep_dup
             icon_args = set_as_hidden_filter_target(icon_args)
 
             if icon_only

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -140,7 +140,13 @@ module Primer
       renders_one :segmented_control, lambda { |**system_arguments, &block|
           deny_tag_argument(**system_arguments)
 
-          @mobile_segmented_control = Primer::Alpha::ActionMenu.new(**system_arguments)
+          system_arguments[:data] = merge_data(
+            system_arguments, {
+              data: {
+                targets: HIDDEN_FILTER_TARGET_SELECTOR
+              }
+            }
+          )
 
           Primer::Alpha::SegmentedControl.new(**system_arguments)
       }

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -22,14 +22,15 @@ module Primer
         button: {
           renders: lambda { |icon: nil, mobile_icon:, mobile_label:, **kwargs|
             if icon
-              Primer::Beta::IconButton.new(icon: icon, display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
+              Primer::Beta::IconButton.new(icon: icon, **kwargs)
             else
-              @mobile_button =  Primer::Beta::IconButton.new(icon: mobile_icon,
-                                                             aria: {
-                                                               label: mobile_label
-                                                             },
-                                                             display: MOBILE_ACTIONS_DISPLAY,
-                                                             **kwargs)
+              @mobile_buttons ||= []
+              @mobile_buttons.push(Primer::Beta::IconButton.new(icon: mobile_icon,
+                                                                aria: {
+                                                                  label: mobile_label
+                                                                },
+                                                                display: MOBILE_ACTIONS_DISPLAY,
+                                                                **kwargs))
 
               Primer::Beta::Button.new(display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
             end
@@ -37,7 +38,15 @@ module Primer
         },
         button_group: {
           renders: lambda { |**kwargs|
-            Primer::Beta::ButtonGroup.new(**kwargs)
+            kwargs[:data] = merge_data(
+              kwargs, {
+                data: {
+                  targets: HIDDEN_FILTER_TARGET_SELECTOR,
+                }
+              }
+            )
+
+            Primer::OpenProject::SubHeader::ButtonGroup.new(**kwargs)
           },
         },
         component: {
@@ -104,8 +113,14 @@ module Primer
               kwargs[:classes],
               "SubHeader-filterButton"
             )
-            kwargs[:data] ||= {}
-            kwargs[:data][:targets] ||= HIDDEN_FILTER_TARGET_SELECTOR
+
+            kwargs[:data] = merge_data(
+              kwargs, {
+                data: {
+                  targets: HIDDEN_FILTER_TARGET_SELECTOR,
+                }
+              }
+            )
 
             kwargs[:mr] ||= 2
 
@@ -130,8 +145,13 @@ module Primer
           renders: lambda { |**kwargs|
             deny_tag_argument(**kwargs)
             kwargs[:tag] = :div
-            kwargs[:data] ||= {}
-            kwargs[:data][:targets] ||= HIDDEN_FILTER_TARGET_SELECTOR
+            kwargs[:data] = merge_data(
+              kwargs, {
+                data: {
+                  targets: HIDDEN_FILTER_TARGET_SELECTOR,
+                }
+              }
+            )
 
             Primer::BaseComponent.new(**kwargs)
           },

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -77,6 +77,7 @@ module Primer
         @mobile_filter_trigger = Primer::Beta::IconButton.new(icon: system_arguments[:leading_visual][:icon],
                                                               display: [:inline_flex, :none],
                                                               aria: { label: label },
+                                                              mr: 2,
                                                               "data-action": "click:sub-header#expandFilterInput",
                                                               "data-targets": HIDDEN_FILTER_TARGET_SELECTOR)
 
@@ -105,6 +106,8 @@ module Primer
             )
             kwargs[:data] ||= {}
             kwargs[:data][:targets] ||= HIDDEN_FILTER_TARGET_SELECTOR
+
+            kwargs[:mr] ||= 2
 
             if icon
               Primer::Beta::IconButton.new(icon: icon, display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
@@ -147,8 +150,16 @@ module Primer
               }
             }
           )
+          system_arguments[:mr] ||= 2
 
-          Primer::Alpha::SegmentedControl.new(**system_arguments)
+          @segmented_control_block = block
+          @mobile_segmented_control = Primer::OpenProject::SubHeader::SegmentedControl.new(
+            hide_labels: true,
+            display: MOBILE_ACTIONS_DISPLAY,
+            **system_arguments
+          )
+
+          Primer::OpenProject::SubHeader::SegmentedControl.new(display: DESKTOP_ACTIONS_DISPLAY, **system_arguments)
       }
 
       renders_one :text, lambda { |**system_arguments|
@@ -174,7 +185,9 @@ module Primer
 
         @filter_container = Primer::BaseComponent.new(tag: :div,
                                                       classes: "SubHeader-filterContainer",
-                                                      display: [:none, :flex],
+                                                      display: DESKTOP_ACTIONS_DISPLAY,
+
+                                                      mr: 2,
                                                       data: { targets: SHOWN_FILTER_TARGET_SELECTOR })
 
         @system_arguments[:classes] = class_names(

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -10,6 +10,9 @@ module Primer
       HIDDEN_FILTER_TARGET_SELECTOR = "sub-header.hiddenItemsOnExpandedFilter"
       SHOWN_FILTER_TARGET_SELECTOR = "sub-header.shownItemsOnExpandedFilter"
 
+      MOBILE_ACTIONS_DISPLAY = [:flex, :none].freeze
+      DESKTOP_ACTIONS_DISPLAY = [:none, :flex].freeze
+
       # A button or custom content that will render on the right-hand side of the component.
       #
       # To render a button, call the `with_button` method, which accepts the arguments accepted by <%= link_to_component(Primer::Beta::Button) %>.
@@ -17,11 +20,18 @@ module Primer
       # To render custom content, call the `with_button_component` method and pass a block that returns HTML.
       renders_many :actions, types: {
         button: {
-          renders: lambda { |icon: nil, **kwargs|
+          renders: lambda { |icon: nil, mobile_icon:, mobile_label:, **kwargs|
             if icon
-              Primer::Beta::IconButton.new(icon: icon, **kwargs)
+              Primer::Beta::IconButton.new(icon: icon, display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
             else
-              Primer::Beta::Button.new(**kwargs)
+              @mobile_button =  Primer::Beta::IconButton.new(icon: mobile_icon,
+                                                             aria: {
+                                                               label: mobile_label
+                                                             },
+                                                             display: MOBILE_ACTIONS_DISPLAY,
+                                                             **kwargs)
+
+              Primer::Beta::Button.new(display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
             end
           },
         },
@@ -83,7 +93,7 @@ module Primer
       # To render custom content, call the `with_filter_component` method and pass a block that returns HTML.
       renders_one :filter_button, types: {
         button: {
-          renders: lambda { |icon: nil, **kwargs|
+          renders: lambda { |icon: nil, mobile_icon: :filter, mobile_label: I18n.t("button_filter"), **kwargs|
             kwargs[:classes] = class_names(
               kwargs[:classes],
               "SubHeader-filterButton"
@@ -92,9 +102,16 @@ module Primer
             kwargs[:data][:targets] ||= HIDDEN_FILTER_TARGET_SELECTOR
 
             if icon
-              Primer::Beta::IconButton.new(icon: icon, **kwargs)
+              Primer::Beta::IconButton.new(icon: icon, display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
             else
-              Primer::Beta::Button.new(**kwargs)
+              @mobile_filter_button =  Primer::Beta::IconButton.new(icon: mobile_icon,
+                                                             aria: {
+                                                               label: mobile_label
+                                                             },
+                                                             display: MOBILE_ACTIONS_DISPLAY,
+                                                             **kwargs)
+
+              Primer::Beta::Button.new(display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
             end
           },
 

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -69,15 +69,6 @@ module Primer
 
             Primer::OpenProject::SubHeader::Menu.new(icon_only: icon_only,display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
           },
-        },
-        component: {
-          # A generic slot to render whatever component you like on the right side
-          renders: lambda { |**kwargs|
-            deny_tag_argument(**kwargs)
-            kwargs[:tag] = :div
-
-            Primer::BaseComponent.new(**kwargs)
-          },
         }
       }
 

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -146,6 +146,13 @@ module Primer
           system_arguments[:classes]
         )
       end
+
+      def before_render
+        @system_arguments[:classes] = class_names(
+          @system_arguments[:classes],
+          "SubHeader--emptyLeftPane" => !segmented_control? && !filter_button && !filter_input
+        )
+      end
     end
   end
 end

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -115,6 +115,14 @@ module Primer
         }
       }
 
+      renders_one :segmented_control, lambda { |**system_arguments, &block|
+          deny_tag_argument(**system_arguments)
+
+          @mobile_segmented_control = Primer::Alpha::ActionMenu.new(**system_arguments)
+
+          Primer::Alpha::SegmentedControl.new(**system_arguments)
+      }
+
       renders_one :text, lambda { |**system_arguments|
         system_arguments[:font_weight] ||= :bold
 

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -20,18 +20,19 @@ module Primer
       # To render custom content, call the `with_button_component` method and pass a block that returns HTML.
       renders_many :actions, types: {
         button: {
-          renders: lambda { |icon_only: false, leading_icon:, mobile_label:, **kwargs|
+          renders: lambda { |icon_only: false, leading_icon:, mobile_label:, **kwargs, &block|
             kwargs[:icon] = leading_icon
 
             if icon_only
               Primer::Beta::IconButton.new(**kwargs)
             else
-              @mobile_buttons ||= []
-              @mobile_buttons.push(Primer::Beta::IconButton.new(aria: {
-                                                                  label: mobile_label
-                                                                },
-                                                                display: MOBILE_ACTIONS_DISPLAY,
-                                                                **kwargs))
+              @mobile_actions ||= []
+              mobile_component =  Primer::Beta::IconButton.new(aria: {
+                                                                 label: mobile_label
+                                                               },
+                                                               display: MOBILE_ACTIONS_DISPLAY,
+                                                               **kwargs)
+              @mobile_actions.push({ component: mobile_component, block: block})
 
               Primer::OpenProject::SubHeader::Button.new(display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
             end
@@ -40,6 +41,21 @@ module Primer
         button_group: {
           renders: lambda { |**kwargs|
             Primer::OpenProject::SubHeader::ButtonGroup.new(**kwargs)
+          },
+        },
+        menu: {
+          renders: lambda { |icon_only: false, leading_icon:, label:, button_arguments: {}, **kwargs, &block|
+            kwargs[:leading_icon] = leading_icon
+            kwargs[:label] = label
+            kwargs[:button_arguments] = button_arguments
+
+            @mobile_actions ||= []
+            mobile_component =  Primer::OpenProject::SubHeader::Menu.new(icon_only: true,
+                                                                         display: MOBILE_ACTIONS_DISPLAY,
+                                                                         **kwargs)
+            @mobile_actions.push({ component: mobile_component, block: block})
+
+            Primer::OpenProject::SubHeader::Menu.new(icon_only: icon_only,display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
           },
         },
         component: {

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -21,6 +21,10 @@ module Primer
       renders_many :actions, types: {
         button: {
           renders: lambda { |icon_only: false, leading_icon:, label:, **kwargs, &block|
+            if label.nil? || label.empty?
+              raise ArgumentError, "You need to provide a valid label."
+            end
+
             kwargs[:icon] = leading_icon
 
             kwargs[:aria] ||= merge_aria(
@@ -47,6 +51,10 @@ module Primer
         },
         menu: {
           renders: lambda { |icon_only: false, leading_icon:, label:, button_arguments: {}, **kwargs, &block|
+            if label.nil? || label.empty?
+              raise ArgumentError, "You need to provide a valid label."
+            end
+
             kwargs[:leading_icon] = leading_icon
             kwargs[:label] = label
             kwargs[:button_arguments] = button_arguments
@@ -72,6 +80,10 @@ module Primer
       }
 
       renders_one :filter_input, lambda { |name:, label:, **system_arguments|
+        if label.nil? || label.empty?
+          raise ArgumentError, "You need to provide a valid label."
+        end
+
         system_arguments[:classes] = class_names(
           system_arguments[:classes],
           "SubHeader-filterInput",

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -20,17 +20,19 @@ module Primer
       # To render custom content, call the `with_button_component` method and pass a block that returns HTML.
       renders_many :actions, types: {
         button: {
-          renders: lambda { |icon_only: false, leading_icon:, mobile_label:, **kwargs, &block|
+          renders: lambda { |icon_only: false, leading_icon:, label:, **kwargs, &block|
             kwargs[:icon] = leading_icon
+
+            kwargs[:aria] ||= merge_aria(
+              kwargs,
+              { aria: { label: label } }
+            )
 
             if icon_only
               Primer::Beta::IconButton.new(**kwargs)
             else
               @mobile_actions ||= []
-              mobile_component =  Primer::Beta::IconButton.new(aria: {
-                                                                 label: mobile_label
-                                                               },
-                                                               display: MOBILE_ACTIONS_DISPLAY,
+              mobile_component =  Primer::Beta::IconButton.new(display: MOBILE_ACTIONS_DISPLAY,
                                                                **kwargs)
               @mobile_actions.push({ component: mobile_component, block: block})
 

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -35,6 +35,11 @@ module Primer
             end
           },
         },
+        button_group: {
+          renders: lambda { |**kwargs|
+            Primer::Beta::ButtonGroup.new(**kwargs)
+          },
+        },
         component: {
           # A generic slot to render whatever component you like on the right side
           renders: lambda { |**kwargs|

--- a/app/components/primer/open_project/sub_header.rb
+++ b/app/components/primer/open_project/sub_header.rb
@@ -20,19 +20,19 @@ module Primer
       # To render custom content, call the `with_button_component` method and pass a block that returns HTML.
       renders_many :actions, types: {
         button: {
-          renders: lambda { |icon: nil, mobile_icon:, mobile_label:, **kwargs|
+          renders: lambda { |icon: nil, leading_icon:, mobile_label:, **kwargs|
             if icon
               Primer::Beta::IconButton.new(icon: icon, **kwargs)
             else
               @mobile_buttons ||= []
-              @mobile_buttons.push(Primer::Beta::IconButton.new(icon: mobile_icon,
+              @mobile_buttons.push(Primer::Beta::IconButton.new(icon: leading_icon,
                                                                 aria: {
                                                                   label: mobile_label
                                                                 },
                                                                 display: MOBILE_ACTIONS_DISPLAY,
                                                                 **kwargs))
 
-              Primer::Beta::Button.new(display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
+              Primer::OpenProject::SubHeader::Button.new(icon: leading_icon, display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
             end
           },
         },
@@ -108,7 +108,7 @@ module Primer
       # To render custom content, call the `with_filter_component` method and pass a block that returns HTML.
       renders_one :filter_button, types: {
         button: {
-          renders: lambda { |icon: nil, mobile_icon: :filter, mobile_label: I18n.t("button_filter"), **kwargs|
+          renders: lambda { |icon: nil, leading_icon: :filter, mobile_label: I18n.t("button_filter"), **kwargs|
             kwargs[:classes] = class_names(
               kwargs[:classes],
               "SubHeader-filterButton"
@@ -127,14 +127,14 @@ module Primer
             if icon
               Primer::Beta::IconButton.new(icon: icon, display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
             else
-              @mobile_filter_button =  Primer::Beta::IconButton.new(icon: mobile_icon,
+              @mobile_filter_button =  Primer::Beta::IconButton.new(icon: leading_icon,
                                                              aria: {
                                                                label: mobile_label
                                                              },
                                                              display: MOBILE_ACTIONS_DISPLAY,
                                                              **kwargs)
 
-              Primer::Beta::Button.new(display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
+              Primer::OpenProject::SubHeader::Button.new(icon: leading_icon, display: DESKTOP_ACTIONS_DISPLAY, **kwargs)
             end
           },
 

--- a/app/components/primer/open_project/sub_header/button.rb
+++ b/app/components/primer/open_project/sub_header/button.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Primer
+  module OpenProject
+    # A Helper class to create a Button with required icon inside the SubHeader action slot
+    # Do not use standalone
+    class SubHeader::Button < Primer::Component
+      status :open_project
+
+      renders_one :leading_visual_icon, lambda { |**system_arguments|
+        # Do nothing as this slot is reserved for the enforced leading icon
+      }
+
+      # @param icon [Symbol] The name of an <%= link_to_octicons %> icon to use as leading visual
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(icon:, **system_arguments)
+        @icon = icon
+        @button = Primer::Beta::Button.new(**system_arguments)
+      end
+
+      delegate :trailing_visual_icon?, :trailing_visual_icon, :with_trailing_visual_icon, :with_trailing_visual_content_icon,
+               :trailing_visual_counter?, :trailing_visual_counter, :with_trailing_visual_counter, :with_trailing_visual_content_counter,
+               :trailing_visual_label?, :trailing_visual_label, :with_trailing_visual_label, :with_trailing_visual_content_label,
+               :trailing_action?, :trailing_action, :with_trailing_action, :with_trailing_action_content,
+               :tooltip?, :tooltip, :with_tooltip, :with_tooltip,
+               to: :@button
+
+      def before_render
+        if leading_visual_icon.present?
+          raise ArgumentError,
+                "Do not use the leading_visual_icon slot within the SubHeader, as it is reserved. Instead provide a leading_icon within the subHeader button slot"
+        end
+      end
+
+      def call
+        render(@button) do |button|
+          button.with_leading_visual_icon(icon: @icon)
+          content
+        end
+      end
+    end
+  end
+end

--- a/app/components/primer/open_project/sub_header/button_group.rb
+++ b/app/components/primer/open_project/sub_header/button_group.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Primer
+  module OpenProject
+    # A Helper class to create ButtonGroups inside the SubHeader action slot
+    # Do not use standalone
+    class SubHeader::ButtonGroup < Primer::Beta::ButtonGroup
+      status :open_project
+
+      def with_button(icon:, **system_arguments, &block)
+        system_arguments[:icon] = icon
+        super(component_klass: Primer::OpenProject::SubHeader::ButtonGroup, **system_arguments, &block)
+      end
+    end
+  end
+end

--- a/app/components/primer/open_project/sub_header/menu.rb
+++ b/app/components/primer/open_project/sub_header/menu.rb
@@ -32,6 +32,11 @@ module Primer
         @icon_only = icon_only
         @leading_icon = leading_icon
         @label = label
+
+        if @label.nil? || @label.empty?
+          raise ArgumentError, "You need to provide a valid label."
+        end
+
         @button_arguments = button_arguments
 
         @menu = Primer::Alpha::ActionMenu.new(**system_arguments)

--- a/app/components/primer/open_project/sub_header/menu.rb
+++ b/app/components/primer/open_project/sub_header/menu.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Primer
+  module OpenProject
+    # A Helper class to create an ActionMenu with a required icon on the trigger button.
+    # It is meant to be used inside the SubHeader
+    # Do not use standalone
+    class SubHeader::Menu < Primer::Component
+      status :open_project
+
+      renders_one :show_button, lambda { |**system_arguments|
+        # Do nothing as this slot is reserved for the enforced leading icon
+      }
+
+      def set_show_button(**system_arguments)
+        if @icon_only
+          @menu.with_show_button(icon: @leading_icon, "aria-label": @label, **system_arguments)
+        else
+          @menu.with_show_button("aria-label": @label, **system_arguments) do |button|
+            button.with_leading_visual_icon(icon: @leading_icon)
+            @label
+          end
+        end
+      end
+
+      # @param icon_only [Boolean] Whether the trigger button is an IconButton
+      # @param leading_icon [Symbol] Name of Octicon icon to use as either leading icon or IconButton.
+      # @param label [String] The button label
+      # @param button_arguments [Hash] Additional arguments for the button
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(icon_only: false, leading_icon:, label:, button_arguments: {}, **system_arguments)
+        @icon_only = icon_only
+        @leading_icon = leading_icon
+        @label = label
+        @button_arguments = button_arguments
+
+        @menu = Primer::Alpha::ActionMenu.new(**system_arguments)
+      end
+
+      delegate :with_item, :with_divider, :with_avatar_item, :with_group,
+               to: :@menu
+
+      def before_render
+        if show_button
+          raise ArgumentError,
+                "Do not use the show_button slot within the SubHeader, as it is reserved. Instead provide a leading_icon within the subHeader button slot"
+        end
+      end
+
+      def call
+        render(@menu) do
+          set_show_button(**@button_arguments)
+          content
+        end
+      end
+    end
+  end
+end

--- a/app/components/primer/open_project/sub_header/menu.rb
+++ b/app/components/primer/open_project/sub_header/menu.rb
@@ -13,10 +13,12 @@ module Primer
       }
 
       def set_show_button(**system_arguments)
+        aria_label = aria("label", system_arguments) || @label
+
         if @icon_only
-          @menu.with_show_button(icon: @leading_icon, "aria-label": @label, **system_arguments)
+          @menu.with_show_button(icon: @leading_icon, "aria-label": aria_label, **system_arguments)
         else
-          @menu.with_show_button("aria-label": @label, **system_arguments) do |button|
+          @menu.with_show_button("aria-label": aria_label, **system_arguments) do |button|
             button.with_leading_visual_icon(icon: @leading_icon)
             button.with_trailing_action_icon(icon: @trailing_icon) unless @trailing_icon.nil?
             @label

--- a/app/components/primer/open_project/sub_header/menu.rb
+++ b/app/components/primer/open_project/sub_header/menu.rb
@@ -18,6 +18,7 @@ module Primer
         else
           @menu.with_show_button("aria-label": @label, **system_arguments) do |button|
             button.with_leading_visual_icon(icon: @leading_icon)
+            button.with_trailing_action_icon(icon: @trailing_icon) unless @trailing_icon.nil?
             @label
           end
         end
@@ -28,9 +29,10 @@ module Primer
       # @param label [String] The button label
       # @param button_arguments [Hash] Additional arguments for the button
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(icon_only: false, leading_icon:, label:, button_arguments: {}, **system_arguments)
+      def initialize(icon_only: false, leading_icon:, label:, trailing_icon: nil, button_arguments: {}, **system_arguments)
         @icon_only = icon_only
         @leading_icon = leading_icon
+        @trailing_icon = trailing_icon
         @label = label
 
         if @label.nil? || @label.empty?

--- a/app/components/primer/open_project/sub_header/segmented_control.rb
+++ b/app/components/primer/open_project/sub_header/segmented_control.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Primer
+  module OpenProject
+    # A Helper class to create SegmentedControls inside the SubHeader action slot
+    # Do not use standalone
+    class SubHeader::SegmentedControl < Primer::Alpha::SegmentedControl
+      status :open_project
+
+      def with_item(icon:, **system_arguments, &block)
+        system_arguments[:icon] = icon
+        super(component_klass: Primer::OpenProject::SubHeader::SegmentedControl, **system_arguments, &block)
+      end
+    end
+  end
+end

--- a/previews/primer/open_project/page_header_preview/create_action.html.erb
+++ b/previews/primer/open_project/page_header_preview/create_action.html.erb
@@ -13,7 +13,7 @@
       "Filter"
     end
 
-    component.with_action_button(scheme: :primary) do |button|
+    component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary) do |button|
       button.with_leading_visual_icon(icon: :plus)
       "User"
     end

--- a/previews/primer/open_project/page_header_preview/create_action.html.erb
+++ b/previews/primer/open_project/page_header_preview/create_action.html.erb
@@ -13,8 +13,7 @@
       "Filter"
     end
 
-    component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary) do |button|
-      button.with_leading_visual_icon(icon: :plus)
+    component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
       "User"
     end
   end

--- a/previews/primer/open_project/page_header_preview/create_action.html.erb
+++ b/previews/primer/open_project/page_header_preview/create_action.html.erb
@@ -13,7 +13,7 @@
       "Filter"
     end
 
-    component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
+    component.with_action_button(leading_icon: :plus, label: "Create", scheme: :primary) do
       "User"
     end
   end

--- a/previews/primer/open_project/sub_header_preview.rb
+++ b/previews/primer/open_project/sub_header_preview.rb
@@ -35,9 +35,8 @@ module Primer
 
           component.with_text { text } unless text.nil?
 
-          component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary) do |button|
-              button.with_leading_visual_icon(icon: :plus)
-              "Create"
+          component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
+            "Create"
           end if show_action_button
         end
       end
@@ -46,13 +45,12 @@ module Primer
       def default
         render(Primer::OpenProject::SubHeader.new) do |component|
           component.with_filter_input(name: "filter", label: "Filter")
-          component.with_filter_button(mobile_icon: :filter, mobile_label: "Filter") do |button|
+          component.with_filter_button do |button|
             button.with_trailing_visual_counter(count: "15")
             "Filter"
           end
 
-          component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary)  do |button|
-            button.with_leading_visual_icon(icon: :plus)
+          component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
             "Create"
           end
         end
@@ -81,7 +79,7 @@ module Primer
       # @label With SegmentedControl
       def segmented_control
         render(Primer::OpenProject::SubHeader.new) do |component|
-          component.with_filter_button(mobile_icon: :filter, mobile_label: "Filter") do |button|
+          component.with_filter_button do |button|
             button.with_trailing_visual_counter(count: "15")
             "Filter"
           end
@@ -91,8 +89,7 @@ module Primer
             control.with_item(tag: :a, href: "#", label: "Raw", icon: :"file-code")
           end
 
-          component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary)  do |button|
-            button.with_leading_visual_icon(icon: :plus)
+          component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
             "Create"
           end
         end
@@ -110,8 +107,7 @@ module Primer
 
           component.with_text { "Hello world!" }
 
-          component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary)  do |button|
-            button.with_leading_visual_icon(icon: :plus)
+          component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
             "Create"
           end
         end

--- a/previews/primer/open_project/sub_header_preview.rb
+++ b/previews/primer/open_project/sub_header_preview.rb
@@ -35,7 +35,7 @@ module Primer
 
           component.with_text { text } unless text.nil?
 
-          component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
+          component.with_action_button(leading_icon: :plus, label: "Create", scheme: :primary) do
             "Create"
           end if show_action_button
         end
@@ -50,7 +50,7 @@ module Primer
             "Filter"
           end
 
-          component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
+          component.with_action_button(leading_icon: :plus, label: "Create", scheme: :primary) do
             "Create"
           end
         end
@@ -89,7 +89,7 @@ module Primer
             control.with_item(tag: :a, href: "#", label: "Raw", icon: :"file-code")
           end
 
-          component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
+          component.with_action_button(leading_icon: :plus, label: "Create", scheme: :primary) do
             "Create"
           end
         end
@@ -107,7 +107,7 @@ module Primer
 
           component.with_text { "Hello world!" }
 
-          component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
+          component.with_action_button(leading_icon: :plus, label: "Create", scheme: :primary) do
             "Create"
           end
         end

--- a/previews/primer/open_project/sub_header_preview.rb
+++ b/previews/primer/open_project/sub_header_preview.rb
@@ -78,6 +78,26 @@ module Primer
         render_with_template(locals: {})
       end
 
+      # @label With SegmentedControl
+      def segmented_control
+        render(Primer::OpenProject::SubHeader.new) do |component|
+          component.with_filter_button(mobile_icon: :filter, mobile_label: "Filter") do |button|
+            button.with_trailing_visual_counter(count: "15")
+            "Filter"
+          end
+
+          component.with_segmented_control("aria-label": "Segmented control") do |control|
+            control.with_item(tag: :a, href: "#", label: "Preview", icon: :eye, selected: true)
+            control.with_item(tag: :a, href: "#", label: "Raw", icon: :"file-code")
+          end
+
+          component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary)  do |button|
+            button.with_leading_visual_icon(icon: :plus)
+            "Create"
+          end
+        end
+      end
+
       # @label With a custom area below
       def bottom_pane
         render_with_template(locals: {})

--- a/previews/primer/open_project/sub_header_preview.rb
+++ b/previews/primer/open_project/sub_header_preview.rb
@@ -35,7 +35,7 @@ module Primer
 
           component.with_text { text } unless text.nil?
 
-          component.with_action_button(scheme: :primary) do |button|
+          component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary) do |button|
               button.with_leading_visual_icon(icon: :plus)
               "Create"
           end if show_action_button
@@ -46,12 +46,12 @@ module Primer
       def default
         render(Primer::OpenProject::SubHeader.new) do |component|
           component.with_filter_input(name: "filter", label: "Filter")
-          component.with_filter_button do |button|
+          component.with_filter_button(mobile_icon: :filter, mobile_label: "Filter") do |button|
             button.with_trailing_visual_counter(count: "15")
             "Filter"
           end
 
-          component.with_action_button(scheme: :primary)  do |button|
+          component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary)  do |button|
             button.with_leading_visual_icon(icon: :plus)
             "Create"
           end
@@ -110,7 +110,7 @@ module Primer
 
           component.with_text { "Hello world!" }
 
-          component.with_action_button(scheme: :primary)  do |button|
+          component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary)  do |button|
             button.with_leading_visual_icon(icon: :plus)
             "Create"
           end

--- a/previews/primer/open_project/sub_header_preview.rb
+++ b/previews/primer/open_project/sub_header_preview.rb
@@ -62,6 +62,9 @@ module Primer
       end
 
       # @label With Dialog
+      # Only async dialogs are supported in the SubHeader.
+      # Since we duplicate the buttons for mobile purposes,
+      # the dialog would otherwise be duplicated (with the same ID) as well
       def dialog_buttons
         render_with_template(locals: {})
       end

--- a/previews/primer/open_project/sub_header_preview/action_menu_buttons.html.erb
+++ b/previews/primer/open_project/sub_header_preview/action_menu_buttons.html.erb
@@ -1,7 +1,7 @@
 <%= render(Primer::OpenProject::SubHeader.new) do |component| %>
   <% component.with_filter_input(name: "filter", label: "Filter") %>
 
-  <% component.with_action_menu(leading_icon: :plus, label: "Create", button_arguments: { scheme: :primary, "aria-label": "Menu"}) do |menu| %>
+  <% component.with_action_menu(leading_icon: :plus, trailing_icon: :"triangle-down", label: "Create", button_arguments: { scheme: :primary, "aria-label": "Menu"}) do |menu| %>
     <%= menu.with_item(label: "Subitem 1") do |item|
           item.with_leading_visual_icon(icon: :paste)
         end

--- a/previews/primer/open_project/sub_header_preview/action_menu_buttons.html.erb
+++ b/previews/primer/open_project/sub_header_preview/action_menu_buttons.html.erb
@@ -1,15 +1,12 @@
 <%= render(Primer::OpenProject::SubHeader.new) do |component| %>
   <% component.with_filter_input(name: "filter", label: "Filter") %>
 
-  <% component.with_action_component do %>
-    <%= render Primer::Alpha::ActionMenu.new(menu_id: "menu-1") do |menu|
-      menu.with_show_button(icon: :"kebab-horizontal", "aria-label": "Menu")
-      menu.with_item(label: "Subitem 1") do |item|
-        item.with_leading_visual_icon(icon: :paste)
-      end
-      menu.with_item(label: "Subitem 2") do |item|
-        item.with_leading_visual_icon(icon: :log)
-      end
-    end %>
+  <% component.with_action_menu(leading_icon: :plus, label: "Create", button_arguments: { scheme: :primary, "aria-label": "Menu"}) do |menu| %>
+    <%= menu.with_item(label: "Subitem 1") do |item|
+          item.with_leading_visual_icon(icon: :paste)
+        end
+        menu.with_item(label: "Subitem 2") do |item|
+          item.with_leading_visual_icon(icon: :log)
+        end %>
   <% end %>
 <% end %>

--- a/previews/primer/open_project/sub_header_preview/button_group.html.erb
+++ b/previews/primer/open_project/sub_header_preview/button_group.html.erb
@@ -7,11 +7,11 @@
     group.with_button(icon: "sort-desc", "aria-label": "Button 3")
   end %>
 
-  <% component.with_action_button(leading_icon: :star, mobile_label: "Star") do
+  <% component.with_action_button(icon_only: true, leading_icon: :star, label: "Star") do
     "Star"
   end %>
 
-  <% component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
+  <% component.with_action_button(leading_icon: :plus, label: "Create", scheme: :primary) do
     "Create"
   end %>
 <% end %>

--- a/previews/primer/open_project/sub_header_preview/button_group.html.erb
+++ b/previews/primer/open_project/sub_header_preview/button_group.html.erb
@@ -7,8 +7,7 @@
     group.with_button(icon: "sort-desc", "aria-label": "Button 3")
   end %>
 
-  <% component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary)  do |button|
-    button.with_leading_visual_icon(icon: :plus)
+  <% component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
     "Create"
   end %>
 <% end %>

--- a/previews/primer/open_project/sub_header_preview/button_group.html.erb
+++ b/previews/primer/open_project/sub_header_preview/button_group.html.erb
@@ -2,8 +2,13 @@
   <% component.with_filter_input(name: "filter", label: "Filter") %>
 
   <% component.with_action_button_group do |group|
-    group.with_button { "Button 1" }
-    group.with_button { "Button 2" }
-    group.with_button { "Button 3" }
+    group.with_button(icon: :note, "aria-label": "Button 1")
+    group.with_button(icon: :rows, "aria-label": "Button 2")
+    group.with_button(icon: "sort-desc", "aria-label": "Button 3")
+  end %>
+
+  <% component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary)  do |button|
+    button.with_leading_visual_icon(icon: :plus)
+    "Create"
   end %>
 <% end %>

--- a/previews/primer/open_project/sub_header_preview/button_group.html.erb
+++ b/previews/primer/open_project/sub_header_preview/button_group.html.erb
@@ -1,11 +1,9 @@
 <%= render(Primer::OpenProject::SubHeader.new) do |component| %>
   <% component.with_filter_input(name: "filter", label: "Filter") %>
 
-  <% component.with_action_component do %>
-    <%= render(Primer::Beta::ButtonGroup.new) do |group|
-      group.with_button { "Button 1" }
-      group.with_button { "Button 2" }
-      group.with_button { "Button 3" }
-    end %>
-  <% end %>
+  <% component.with_action_button_group do |group|
+    group.with_button { "Button 1" }
+    group.with_button { "Button 2" }
+    group.with_button { "Button 3" }
+  end %>
 <% end %>

--- a/previews/primer/open_project/sub_header_preview/button_group.html.erb
+++ b/previews/primer/open_project/sub_header_preview/button_group.html.erb
@@ -7,6 +7,10 @@
     group.with_button(icon: "sort-desc", "aria-label": "Button 3")
   end %>
 
+  <% component.with_action_button(leading_icon: :star, mobile_label: "Star") do
+    "Star"
+  end %>
+
   <% component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do
     "Create"
   end %>

--- a/previews/primer/open_project/sub_header_preview/custom_filter_button.html.erb
+++ b/previews/primer/open_project/sub_header_preview/custom_filter_button.html.erb
@@ -3,6 +3,6 @@
   <% component.with_filter_component do %>
     <!-- Render any custom filter component that you want -->
     <!-- Note, that you can pass an ID for the bottom pane if you need to access that area for further filter actions-->
-    <%= render(Primer::Beta::IconButton.new(icon: "filter", "aria-label": "Filter")) %>
+    <%= render(Primer::Beta::IconButton.new(icon: "filter-remove", "aria-label": "Filter")) %>
   <% end %>
 <% end %>

--- a/previews/primer/open_project/sub_header_preview/dialog_buttons.html.erb
+++ b/previews/primer/open_project/sub_header_preview/dialog_buttons.html.erb
@@ -1,12 +1,13 @@
 <%= render(Primer::OpenProject::SubHeader.new) do |component| %>
   <% component.with_filter_input(name: "filter", label: "Filter") %>
 
-  <% component.with_action_component do %>
-    <%= render(Primer::Alpha::Dialog.new(id: "dialog-one", title: "Dialog")) do |d| %>
-      <% d.with_show_button { "Show Dialog" } %>
-      <% d.with_body do %>
-        Hello world!
-      <% end %>
-    <% end %>
-  <% end %>
+  <% component.with_text { "Only async dialogs are supported in the SubHeader!" } %>
+
+  <% component.with_action_button(leading_icon: :alert,
+                                  label: "Open Dialog",
+                                  #tag: :a,
+                                  #href: "show_dialog_path",
+                                  data: { controller: "async-dialog" }) do
+    "Open Dialog"
+  end %>
 <% end %>

--- a/static/classes.json
+++ b/static/classes.json
@@ -619,6 +619,9 @@
   "SubHeader": [
     "Primer::OpenProject::SubHeader"
   ],
+  "SubHeader--emptyLeftPane": [
+    "Primer::OpenProject::SubHeader"
+  ],
   "SubHeader--expandedSearch": [
     "Primer::OpenProject::SubHeader"
   ],

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -223,6 +223,7 @@ class PrimerComponentTest < Minitest::Test
       "Primer::OpenProject::PageHeader::Title",
       "Primer::OpenProject::SubHeader::Button",
       "Primer::OpenProject::SubHeader::ButtonGroup",
+      "Primer::OpenProject::SubHeader::Menu",
       "Primer::OpenProject::SubHeader::SegmentedControl",
       "Primer::OpenProject::SidePanel::Section",
       "Primer::OpenProject::DangerDialog::FormWrapper",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -221,6 +221,7 @@ class PrimerComponentTest < Minitest::Test
       "Primer::OpenProject::PageHeader::Menu",
       "Primer::OpenProject::PageHeader::Dialog",
       "Primer::OpenProject::PageHeader::Title",
+      "Primer::OpenProject::SubHeader::SegmentedControl",
       "Primer::OpenProject::SidePanel::Section",
       "Primer::OpenProject::DangerDialog::FormWrapper",
       "Primer::OpenProject::TreeView::IconPair",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -221,6 +221,7 @@ class PrimerComponentTest < Minitest::Test
       "Primer::OpenProject::PageHeader::Menu",
       "Primer::OpenProject::PageHeader::Dialog",
       "Primer::OpenProject::PageHeader::Title",
+      "Primer::OpenProject::SubHeader::ButtonGroup",
       "Primer::OpenProject::SubHeader::SegmentedControl",
       "Primer::OpenProject::SidePanel::Section",
       "Primer::OpenProject::DangerDialog::FormWrapper",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -221,6 +221,7 @@ class PrimerComponentTest < Minitest::Test
       "Primer::OpenProject::PageHeader::Menu",
       "Primer::OpenProject::PageHeader::Dialog",
       "Primer::OpenProject::PageHeader::Title",
+      "Primer::OpenProject::SubHeader::Button",
       "Primer::OpenProject::SubHeader::ButtonGroup",
       "Primer::OpenProject::SubHeader::SegmentedControl",
       "Primer::OpenProject::SidePanel::Section",

--- a/test/components/primer/open_project/sub_header/button_group_test.rb
+++ b/test/components/primer/open_project/sub_header/button_group_test.rb
@@ -17,7 +17,7 @@ class Primer::OpenProject::SubHeader::ButtonGroupTest < Minitest::Test
     assert_text("Button 3")
   end
 
-  def does_not_render_without_icon
+  def test_does_not_render_without_icon
     err = assert_raises ArgumentError do
       render_inline(Primer::OpenProject::SubHeader::ButtonGroup.new) do |group|
         group.with_button("aria-label": "Button 1")
@@ -26,6 +26,6 @@ class Primer::OpenProject::SubHeader::ButtonGroupTest < Minitest::Test
       end
     end
 
-    assert_equal "missing keyword :icon", err.message
+    assert_equal "missing keyword: :icon", err.message
   end
 end

--- a/test/components/primer/open_project/sub_header/button_group_test.rb
+++ b/test/components/primer/open_project/sub_header/button_group_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "components/test_helper"
+
+class Primer::OpenProject::SubHeader::ButtonGroupTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  def test_renders
+    render_inline(Primer::OpenProject::SubHeader::ButtonGroup.new) do |group|
+      group.with_button(icon: :note, "aria-label": "Button 1")
+      group.with_button(icon: :rows, "aria-label": "Button 2")
+      group.with_button(icon: "sort-desc", "aria-label": "Button 3")
+    end
+
+    assert_text("Button 1")
+    assert_text("Button 2")
+    assert_text("Button 3")
+  end
+
+  def does_not_render_without_icon
+    err = assert_raises ArgumentError do
+      render_inline(Primer::OpenProject::SubHeader::ButtonGroup.new) do |group|
+        group.with_button("aria-label": "Button 1")
+        group.with_button("aria-label": "Button 2")
+        group.with_button("aria-label": "Button 3")
+      end
+    end
+
+    assert_equal "missing keyword :icon", err.message
+  end
+end

--- a/test/components/primer/open_project/sub_header/button_test.rb
+++ b/test/components/primer/open_project/sub_header/button_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "components/test_helper"
+
+class Primer::OpenProject::SubHeader::ButtonGroupTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  def test_renders
+    render_inline(Primer::OpenProject::SubHeader::Button.new(icon: :star)) do
+      "Hello World"
+    end
+
+    assert_selector("button") do
+      assert_selector(".octicon.octicon-star")
+      assert_text("Hello World")
+    end
+  end
+
+  def does_not_render_without_icon
+    err = assert_raises ArgumentError do
+      render_inline(Primer::OpenProject::SubHeader::Button.new)
+    end
+
+    assert_equal "missing keyword :icon", err.message
+  end
+
+  def does_not_render_with_a_leading_icon_slot
+    err = assert_raises ArgumentError do
+      render_inline(Primer::OpenProject::SubHeader::Button.new(icon: :star)) do |button|
+        button.with_leading_visual_icon(icon :star)
+        "Hello World"
+      end
+    end
+
+    assert_equal "Do not use the leading_visual_icon slot within the SubHeader, as it is reserved. Instead provide a leading_icon within the subHeader button slot", err.message
+  end
+end

--- a/test/components/primer/open_project/sub_header/button_test.rb
+++ b/test/components/primer/open_project/sub_header/button_test.rb
@@ -2,7 +2,7 @@
 
 require "components/test_helper"
 
-class Primer::OpenProject::SubHeader::ButtonGroupTest < Minitest::Test
+class Primer::OpenProject::SubHeader::ButtonTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
   def test_renders
@@ -16,18 +16,18 @@ class Primer::OpenProject::SubHeader::ButtonGroupTest < Minitest::Test
     end
   end
 
-  def does_not_render_without_icon
+  def test_does_not_render_without_icon
     err = assert_raises ArgumentError do
       render_inline(Primer::OpenProject::SubHeader::Button.new)
     end
 
-    assert_equal "missing keyword :icon", err.message
+    assert_equal "missing keyword: :icon", err.message
   end
 
-  def does_not_render_with_a_leading_icon_slot
+  def test_does_not_render_with_a_leading_icon_slot
     err = assert_raises ArgumentError do
       render_inline(Primer::OpenProject::SubHeader::Button.new(icon: :star)) do |button|
-        button.with_leading_visual_icon(icon :star)
+        button.with_leading_visual_icon(icon: :star)
         "Hello World"
       end
     end

--- a/test/components/primer/open_project/sub_header/menu_test.rb
+++ b/test/components/primer/open_project/sub_header/menu_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "components/test_helper"
+
+class Primer::OpenProject::SubHeader::ButtonTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  def test_renders
+    render_inline(Primer::OpenProject::SubHeader::Menu.new(leading_icon: :star, label: "Hello")) do |menu|
+      menu.with_item(label: "Subitem 1") do |item|
+        item.with_leading_visual_icon(icon: :paste)
+      end
+      menu.with_item(label: "Subitem 2") do |item|
+        item.with_leading_visual_icon(icon: :log)
+      end
+    end
+
+    assert_selector(".Button-leadingVisual .octicon-star")
+
+    assert_selector("ul[role=menu]") do
+      assert_selector ".ActionListItem", text: "Subitem 1"
+      assert_selector ".ActionListItem", text: "Subitem 2"
+    end
+  end
+
+  def test_renders_an_icon_button
+    render_inline(Primer::OpenProject::SubHeader::Menu.new(icon_only: true, leading_icon: :star, label: "Hello")) do |menu|
+      menu.with_item(label: "Subitem 1") do |item|
+        item.with_leading_visual_icon(icon: :paste)
+      end
+      menu.with_item(label: "Subitem 2") do |item|
+        item.with_leading_visual_icon(icon: :log)
+      end
+    end
+
+    assert_no_selector(".Button-leadingVisual .octicon-star")
+    assert_selector(".Button--iconOnly.d-flex .octicon-star")
+
+    assert_selector("ul[role=menu]") do
+      assert_selector ".ActionListItem", text: "Subitem 1"
+      assert_selector ".ActionListItem", text: "Subitem 2"
+    end
+  end
+
+  def test_does_not_render_without_icon
+    err = assert_raises ArgumentError do
+      render_inline(Primer::OpenProject::SubHeader::Menu.new(label: "Hello")) do |menu|
+        menu.with_item(label: "Subitem 1") do |item|
+          item.with_leading_visual_icon(icon: :paste)
+        end
+        menu.with_item(label: "Subitem 2") do |item|
+          item.with_leading_visual_icon(icon: :log)
+        end
+      end
+    end
+
+    assert_equal "missing keyword: :leading_icon", err.message
+  end
+
+  def test_does_not_render_with_a_show_button_slot
+    err = assert_raises ArgumentError do
+      render_inline(Primer::OpenProject::SubHeader::Menu.new(leading_icon: :star, label: "Hello")) do |menu|
+        menu.with_show_button { "Hello" }
+        menu.with_item(label: "Subitem 1") do |item|
+          item.with_leading_visual_icon(icon: :paste)
+        end
+        menu.with_item(label: "Subitem 2") do |item|
+          item.with_leading_visual_icon(icon: :log)
+        end
+      end
+    end
+
+    assert_equal "Do not use the show_button slot within the SubHeader, as it is reserved. Instead provide a leading_icon within the subHeader button slot", err.message
+  end
+end

--- a/test/components/primer/open_project/sub_header/menu_test.rb
+++ b/test/components/primer/open_project/sub_header/menu_test.rb
@@ -34,7 +34,7 @@ class Primer::OpenProject::SubHeader::ButtonTest < Minitest::Test
     end
 
     assert_no_selector(".Button-leadingVisual .octicon-star")
-    assert_selector(".Button--iconOnly.d-flex .octicon-star")
+    assert_selector(".Button--iconOnly .octicon-star")
 
     assert_selector("ul[role=menu]") do
       assert_selector ".ActionListItem", text: "Subitem 1"

--- a/test/components/primer/open_project/sub_header/menu_test.rb
+++ b/test/components/primer/open_project/sub_header/menu_test.rb
@@ -72,4 +72,19 @@ class Primer::OpenProject::SubHeader::ButtonTest < Minitest::Test
 
     assert_equal "Do not use the show_button slot within the SubHeader, as it is reserved. Instead provide a leading_icon within the subHeader button slot", err.message
   end
+
+  def test_does_not_render_without_a_label
+    err = assert_raises ArgumentError do
+      render_inline(Primer::OpenProject::SubHeader::Menu.new(leading_icon: :star, label: "")) do |menu|
+        menu.with_item(label: "Subitem 1") do |item|
+          item.with_leading_visual_icon(icon: :paste)
+        end
+        menu.with_item(label: "Subitem 2") do |item|
+          item.with_leading_visual_icon(icon: :log)
+        end
+      end
+    end
+
+    assert_equal "You need to provide a valid label.", err.message
+  end
 end

--- a/test/components/primer/open_project/sub_header/segemented_control_test.rb
+++ b/test/components/primer/open_project/sub_header/segemented_control_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "components/test_helper"
+
+class Primer::OpenProject::SubHeader::SegmentedControlTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  def test_renders
+    render_inline(Primer::OpenProject::SubHeader::SegmentedControl.new("aria-label": "Segmented control")) do |control|
+      control.with_item(tag: :a, href: "#", label: "Preview", icon: :eye, selected: true)
+      control.with_item(tag: :a, href: "#", label: "Raw", icon: :"file-code")
+    end
+
+    assert_text("Preview")
+    assert_text("Raw")
+  end
+
+  def does_not_render_without_icon
+    err = assert_raises ArgumentError do
+      render_inline(Primer::OpenProject::SubHeader::SegmentedControl.new("aria-label": "Segmented control")) do |control|
+        control.with_item(tag: :a, href: "#", label: "Preview", selected: true)
+        control.with_item(tag: :a, href: "#", label: "Raw")
+      end
+    end
+
+    assert_equal "missing keyword :icon", err.message
+  end
+end

--- a/test/components/primer/open_project/sub_header/segemented_control_test.rb
+++ b/test/components/primer/open_project/sub_header/segemented_control_test.rb
@@ -15,7 +15,7 @@ class Primer::OpenProject::SubHeader::SegmentedControlTest < Minitest::Test
     assert_text("Raw")
   end
 
-  def does_not_render_without_icon
+  def test_does_not_render_without_icon
     err = assert_raises ArgumentError do
       render_inline(Primer::OpenProject::SubHeader::SegmentedControl.new("aria-label": "Segmented control")) do |control|
         control.with_item(tag: :a, href: "#", label: "Preview", selected: true)
@@ -23,6 +23,6 @@ class Primer::OpenProject::SubHeader::SegmentedControlTest < Minitest::Test
       end
     end
 
-    assert_equal "missing keyword :icon", err.message
+    assert_equal "missing keyword: :icon", err.message
   end
 end

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -35,17 +35,17 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
   def test_renders_a_button_group_as_action
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
       component.with_action_button_group do |group|
-        group.with_button { "Button 1" }
-        group.with_button { "Button 2" }
-        group.with_button { "Button 3" }
+        group.with_button(icon: :note, "aria-label": "Button 1")
+        group.with_button(icon: :rows, "aria-label": "Button 2")
+        group.with_button(icon: "sort-desc", "aria-label": "Button 3")
       end
     end
 
     assert_selector(".SubHeader")
     assert_selector(".SubHeader .ButtonGroup")
-    assert_text("Button 1")
-    assert_text("Button 2")
-    assert_text("Button 3")
+    assert_selector(".octicon.octicon-note")
+    assert_selector(".octicon.octicon-rows")
+    assert_selector(".octicon.octicon-sort-desc")
   end
 
   def test_renders_a_custom_button_as_action

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -8,11 +8,10 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
   def test_renders
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
       component.with_filter_input(name: "filter", label: "Filter")
-      component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary) do |button|
-        button.with_leading_visual_icon(icon: :plus)
+      component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do |button|
         "Create"
       end
-      component.with_action_button(mobile_icon: :trash, mobile_label: "Delete", scheme: :danger) { "Delete" }
+      component.with_action_button(leading_icon: :trash, mobile_label: "Delete", scheme: :danger) { "Delete" }
     end
 
     assert_selector(".SubHeader")
@@ -25,7 +24,7 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
 
   def test_renders_an_icon_button_as_action
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
-      component.with_action_button(icon: :plus, mobile_icon: :plus, mobile_label: "Create", aria: { label: "Create" })
+      component.with_action_button(icon: :plus, leading_icon: :plus, mobile_label: "Create", aria: { label: "Create" })
     end
 
     assert_selector(".SubHeader")

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -32,6 +32,22 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
     assert_selector(".SubHeader .Button--iconOnly")
   end
 
+  def test_renders_a_button_group_as_action
+    render_inline(Primer::OpenProject::SubHeader.new) do |component|
+      component.with_action_button_group do |group|
+        group.with_button { "Button 1" }
+        group.with_button { "Button 2" }
+        group.with_button { "Button 3" }
+      end
+    end
+
+    assert_selector(".SubHeader")
+    assert_selector(".SubHeader .ButtonGroup")
+    assert_text("Button 1")
+    assert_text("Button 2")
+    assert_text("Button 3")
+  end
+
   def test_renders_a_custom_button_as_action
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
       component.with_action_component do
@@ -109,6 +125,20 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
       "[data-action=\" input:sub-header#toggleFilterInputClearButton focus:sub-header#toggleFilterInputClearButton\"]"
     )
     assert_selector(".FormControl-input-trailingAction[data-action=\"click:primer-text-field#clearContents\"]")
+  end
+
+  def test_renders_a_segmented_control
+    render_inline(Primer::OpenProject::SubHeader.new) do |component|
+      component.with_segmented_control("aria-label": "Segmented control") do |control|
+        control.with_item(tag: :a, href: "#", label: "Preview", icon: :eye, selected: true)
+        control.with_item(tag: :a, href: "#", label: "Raw", icon: :"file-code")
+      end
+    end
+
+    assert_selector(".SubHeader")
+    assert_selector(".SubHeader .SegmentedControl")
+    assert_text("Preview")
+    assert_text("Raw")
   end
 
   def test_does_not_render_input_events_when_show_clear_button_is_not_set

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -8,11 +8,11 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
   def test_renders
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
       component.with_filter_input(name: "filter", label: "Filter")
-      component.with_action_button(scheme: :primary) do |button|
+      component.with_action_button(mobile_icon: :plus, mobile_label: "Create", scheme: :primary) do |button|
         button.with_leading_visual_icon(icon: :plus)
         "Create"
       end
-      component.with_action_button(scheme: :danger) { "Delete" }
+      component.with_action_button(mobile_icon: :trash, mobile_label: "Delete", scheme: :danger) { "Delete" }
     end
 
     assert_selector(".SubHeader")
@@ -25,7 +25,7 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
 
   def test_renders_an_icon_button_as_action
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
-      component.with_action_button(icon: :plus, aria: { label: "Create" })
+      component.with_action_button(icon: :plus, mobile_icon: :plus, mobile_label: "Create", aria: { label: "Create" })
     end
 
     assert_selector(".SubHeader")

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -8,10 +8,10 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
   def test_renders
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
       component.with_filter_input(name: "filter", label: "Filter")
-      component.with_action_button(leading_icon: :plus, mobile_label: "Create", scheme: :primary) do |button|
+      component.with_action_button(leading_icon: :plus, label: "Create", scheme: :primary) do |button|
         "Create"
       end
-      component.with_action_button(leading_icon: :trash, mobile_label: "Delete", scheme: :danger) { "Delete" }
+      component.with_action_button(leading_icon: :trash, label: "Delete", scheme: :danger) { "Delete" }
     end
 
     assert_selector(".SubHeader")
@@ -24,7 +24,7 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
 
   def test_renders_an_icon_button_as_action
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
-      component.with_action_button(icon_only: true, leading_icon: :plus, mobile_label: "Create", aria: { label: "Create" })
+      component.with_action_button(icon_only: true, leading_icon: :plus, label: "Create", aria: { label: "Create" })
     end
 
     assert_selector(".SubHeader")

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -24,7 +24,7 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
 
   def test_renders_an_icon_button_as_action
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
-      component.with_action_button(icon: :plus, leading_icon: :plus, mobile_label: "Create", aria: { label: "Create" })
+      component.with_action_button(icon_only: true, leading_icon: :plus, mobile_label: "Create", aria: { label: "Create" })
     end
 
     assert_selector(".SubHeader")
@@ -79,8 +79,9 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
     end
 
     assert_selector(".SubHeader")
-    assert_selector(".SubHeader-filterButton")
-    assert_text("Filter")
+    assert_selector(".SubHeader-leftPane") do
+      assert_text("Filter")
+    end
   end
 
 
@@ -90,7 +91,7 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
     end
 
     assert_selector(".SubHeader")
-    assert_selector(".SubHeader-filterButton.Button--iconOnly .octicon-filter")
+    assert_selector(".SubHeader-leftPane .Button--iconOnly .octicon-filter")
   end
 
   def test_renders_a_custom_filter_button
@@ -138,6 +139,17 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
     assert_selector(".SubHeader .SegmentedControl")
     assert_text("Preview")
     assert_text("Raw")
+  end
+
+  def test_renders_empty_left_pane
+    render_inline(Primer::OpenProject::SubHeader.new) do |component|
+      component.with_action_button_group do |group|
+        group.with_button(icon: :note, "aria-label": "Button 1")
+        group.with_button(icon: :rows, "aria-label": "Button 2")
+      end
+    end
+
+    assert_selector(".SubHeader.SubHeader--emptyLeftPane")
   end
 
   def test_does_not_render_input_events_when_show_clear_button_is_not_set

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -31,6 +31,16 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
     assert_selector(".SubHeader .Button--iconOnly")
   end
 
+  def test_renders_a_button_without_label
+    err = assert_raises ArgumentError do
+      render_inline(Primer::OpenProject::SubHeader.new) do |component|
+        component.with_action_button(icon_only: true, leading_icon: :plus, label: "", aria: { label: "Create" })
+      end
+    end
+
+    assert_equal "You need to provide a valid label.", err.message
+  end
+
   def test_renders_a_button_group_as_action
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
       component.with_action_button_group do |group|
@@ -64,6 +74,23 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
       assert_selector ".ActionListItem", text: "Foo"
       assert_selector ".ActionListItem", text: "Bar"
     end
+  end
+
+  def test_renders_a_menu_without_label
+    err = assert_raises ArgumentError do
+      render_inline(Primer::OpenProject::SubHeader.new) do |component|
+        component.with_action_menu(leading_icon: :plus, label: "", button_arguments: { scheme: :primary, "aria-label": "Menu"}) do |menu|
+          menu.with_item(label: "Foo") do |item|
+            item.with_leading_visual_icon(icon: :paste)
+          end
+          menu.with_item(label: "Bar") do |item|
+            item.with_leading_visual_icon(icon: :log)
+          end
+        end
+      end
+    end
+
+    assert_equal "You need to provide a valid label.", err.message
   end
 
   def test_renders_a_custom_button_as_action
@@ -155,6 +182,21 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
       "[data-action=\" input:sub-header#toggleFilterInputClearButton focus:sub-header#toggleFilterInputClearButton\"]"
     )
     assert_selector(".FormControl-input-trailingAction[data-action=\"click:primer-text-field#clearContents\"]")
+  end
+
+  def test_renders_a_filter_input_label
+    err = assert_raises ArgumentError do
+      render_inline(Primer::OpenProject::SubHeader.new) do |component|
+        component.with_filter_input(
+          name: "filter",
+          label: "",
+          show_clear_button: true,
+          value: "value is set"
+        )
+      end
+    end
+
+    assert_equal "You need to provide a valid label.", err.message
   end
 
   def test_renders_a_segmented_control

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -93,20 +93,6 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
     assert_equal "You need to provide a valid label.", err.message
   end
 
-  def test_renders_a_custom_button_as_action
-    render_inline(Primer::OpenProject::SubHeader.new) do |component|
-      component.with_action_component do
-        "<div class='ButtonGroup'><div><button class='MyCustomClass'>Button 1</button></div><div><button class='MyCustomClass'>Button 2</button></div></div>".html_safe
-      end
-    end
-
-    assert_selector(".SubHeader")
-    assert_selector(".SubHeader .ButtonGroup")
-    assert_selector(".SubHeader .MyCustomClass")
-    assert_text("Button 1")
-    assert_text("Button 2")
-  end
-
   def test_renders_a_text
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
       component.with_text { "Hello world!" }

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -103,6 +103,17 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
     end
   end
 
+  def test_renders_an_icon_button_as_filter_button
+    render_inline(Primer::OpenProject::SubHeader.new) do |component|
+      component.with_filter_button(icon_only: true)
+    end
+
+    assert_selector(".SubHeader")
+    assert_selector(".SubHeader-leftPane") do
+      assert_selector(".SubHeader .Button--iconOnly")
+      assert_selector(".octicon.octicon-filter")
+    end
+  end
 
   def test_renders_an_icon_filter_button
     render_inline(Primer::OpenProject::SubHeader.new) do |component|

--- a/test/components/primer/open_project/sub_header_test.rb
+++ b/test/components/primer/open_project/sub_header_test.rb
@@ -47,6 +47,25 @@ class PrimerOpenProjectSubHeaderTest < Minitest::Test
     assert_selector(".octicon.octicon-sort-desc")
   end
 
+  def test_renders_a_menu_as_action
+    render_inline(Primer::OpenProject::SubHeader.new) do |component|
+      component.with_action_menu(leading_icon: :plus, label: "Create", button_arguments: { scheme: :primary, "aria-label": "Menu"}) do |menu|
+        menu.with_item(label: "Foo") do |item|
+          item.with_leading_visual_icon(icon: :paste)
+        end
+        menu.with_item(label: "Bar") do |item|
+          item.with_leading_visual_icon(icon: :log)
+        end
+      end
+    end
+
+    assert_selector(".Button-leadingVisual .octicon-plus")
+    assert_selector("ul[role=menu]") do
+      assert_selector ".ActionListItem", text: "Foo"
+      assert_selector ".ActionListItem", text: "Bar"
+    end
+  end
+
   def test_renders_a_custom_button_as_action
     render_inline(Primer::OpenProject::SubHeader.new) do |component|
       component.with_action_component do

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -187,7 +187,9 @@ class ComponentSpecificSelectorsTest < Minitest::Test
     ],
     Primer::OpenProject::SubHeader => [
       ".SubHeader--expandedSearch",
-      ".SubHeader-filterInput_hiddenClearButton"
+      ".SubHeader-filterInput_hiddenClearButton",
+      ".SubHeader--emptyLeftPane",
+      ".SubHeader--emptyLeftPane .SubHeader-middlePane"
     ],
     Primer::OpenProject::TreeView => [
       # Used, but not directly rendered by a preview


### PR DESCRIPTION
### What are you trying to accomplish?

Improve the mobile behaviour of the SubHeader by collapsing all buttons to icon-only variants. In that scope, we enforce icons on all buttons even in the desktop variant.

**ToDo**
- [x] All buttons will be enforce to show a leading icon on desktop to which they can collapse to on mobile
- [x] Create a slot for `SegmentedControl`
  - [x] Enforce icons for the segmentedControl (even on desktop) 
  - [x] The `SegmentedControl` turns into an icon-only variant
- [x] Create a slot for an icon-only `ButtonGroup`
- [x] Create a slot for an ActionMenu that enforces a leading icon
- [x] If there are no actions on the left side of the SubHeader on desktop, this space will remain empty on mobile too
- [x]  The center text will:
  - [x] If left slot is empty: go to left side and truncate to available width
  - [x] If left slot is not empty: go to a new line and is left aligned
- [x] All actions that do not have a visible label need a title or ARIA label for accessibilty

### Screenshots
<img width="300" alt="Bildschirmfoto 2025-05-09 um 08 42 28" src="https://github.com/user-attachments/assets/ab3e630a-0669-45fd-8327-a0ce288dfc54" />
<img width="300" alt="Bildschirmfoto 2025-05-09 um 08 42 41" src="https://github.com/user-attachments/assets/acaf6ea0-f2f2-40a4-a80e-017bda9b1751" />
<img width="300" alt="Bildschirmfoto 2025-05-09 um 08 42 53" src="https://github.com/user-attachments/assets/3506bded-0494-4eb9-96d3-65b5716a7a94" />
<img width="300" alt="Bildschirmfoto 2025-05-09 um 08 43 23" src="https://github.com/user-attachments/assets/c694bc3f-fe0b-4839-8610-1f8a11c54235" />

### What approach did you choose and why
I created SubClasses for all possible types of actions that the SubHeader can have, in order to enfore the icon to be set. The only exception are the free `filter_button_component` and `action_component` slots that currently allow anything to be rendered. There, we cannot enforce the icons. The goal is to remove those slots, but that is out of scope for now


#### List the issues that this change affects.
https://community.openproject.org/projects/openproject/work_packages/60332/activity

#### Risk Assessment

- [x] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.


### Merge checklist

- [x] Added/updated tests
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
