### PR TITLE
Fix flickering TreeView test

### DIFF
--- a/test/system/open_project/tree_view_test.rb
+++ b/test/system/open_project/tree_view_test.rb
@@ -290,6 +290,7 @@ module OpenProject
       visit_preview(:loading_spinner, simulate_empty: true)
 
       activate_at_path("primer")
+      refute_selector("tree-view-include-fragment") # wait for fragment to load
 
       assert_selector "#{selector_for("primer")} .TreeViewItemContentText", text: "No items"
     end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR is designed to address a flickering (i.e. occasionally failing) `TreeView` test, as can be seen here: https://github.com/opf/primer_view_components/actions/runs/14855158207/job/41706622240

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production - this update affects tests only.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

I added an `assert_selector` statement that waits for the async request to finish before asserting the "No items" item exists.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.