### PR TITLE
Skip CSS use test for `TreeView`'s playground preview

### DIFF
--- a/test/css/component_selector_use_test.rb
+++ b/test/css/component_selector_use_test.rb
@@ -23,6 +23,12 @@ IGNORED_SELECTORS = {
 }.freeze
 # rubocop:enable Style/WordArray
 
+IGNORED_PREVIEWS = {
+  # Computationally-intensive; selectors checked by other previews
+  Primer::OpenProject::TreeView => [:playground],
+  Primer::OpenProject::FileTreeView => [:playground]
+}
+
 # Test CSS Selectors Used By Components
 # ----
 #
@@ -49,6 +55,8 @@ class ComponentSelectorUseTest < System::TestCase
     component_uri = preview_class.to_s.underscore.gsub("_preview", "")
 
     previews.each do |preview|
+      next if IGNORED_PREVIEWS.fetch(component_class, []).include?(preview)
+
       define_method("test_selectors_used_by_#{component_uri.parameterize(separator: '_')}_#{preview}_are_valid") do
         Capybara.current_session.using_wait_time(10) do
           visit("/rails/view_components/#{component_uri}/#{preview}")


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

The CSS selector use test is still flickering (i.e. failing intermittently) because it's computationally intensive to process all the HTML for the `TreeView` and `FileTreeView` playground previews. This PR ignores these two previews, which should be safe to do because other previews also provide the same selector information.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production - this update is test-only.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.