### PR TITLE
Push new tag when releasing

### DIFF
--- a/script/changeset-publish
+++ b/script/changeset-publish
@@ -1,6 +1,15 @@
+#!/bin/bash
+set -e
+
 # Get the current version
 PACKAGE_VERSION=$(jq '.version' --raw-output ./package.json)
+TAG_NAME="v$PACKAGE_VERSION"
 
 # Check if the remote has the current version as a git tag
 # If it doesn't, we echo "New tag:" which is what the changeset action expects https://github.com/changesets/action/blob/b98cec97583b917ff1dc6179dd4d230d3e439894/src/run.ts#L123
-git ls-remote --exit-code --tags origin "v$PACKAGE_VERSION" || echo "New tag:"
+# And push the new tag
+if ! git ls-remote --exit-code --tags origin "$TAG_NAME" > /dev/null; then
+  echo "New tag:"
+  git tag "$TAG_NAME"
+  git push origin "$TAG_NAME"
+fi


### PR DESCRIPTION


### What are you trying to accomplish?
Create local tag and push it before continuing with the changeset action. This is necessary because of recent changes in the changeset action script. See https://github.com/changesets/action/issues/465#issuecomment-2862152850

