### PR TITLE
[64149] Raise an error if no string is passed to the CollapsibleSection

### DIFF
--- a/.changeset/thin-jeans-help.md
+++ b/.changeset/thin-jeans-help.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Enforce title for CollapsibleSection and CollapsibleHeader to be a String

--- a/app/components/primer/open_project/border_box/collapsible_header.rb
+++ b/app/components/primer/open_project/border_box/collapsible_header.rb
@@ -12,6 +12,8 @@ module Primer
         #
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
         renders_one :title, lambda { |**system_arguments, &block|
+          raise ArgumentError, "Title must be a string" unless block.call.is_a?(String)
+
           system_arguments[:mr] ||= 2
 
           Primer::Beta::Text.new(**system_arguments, &block)
@@ -31,6 +33,7 @@ module Primer
         #
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
         renders_one :description, lambda { |**system_arguments, &block|
+          raise ArgumentError, "Description must be a string" unless block.call.is_a?(String)
           system_arguments[:color] ||= :subtle
           system_arguments[:hidden] = @collapsed
 

--- a/app/components/primer/open_project/collapsible_section.rb
+++ b/app/components/primer/open_project/collapsible_section.rb
@@ -15,6 +15,8 @@ module Primer
       # @param tag [Symbol] Customize the element type of the rendered title container.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :title, lambda { |tag: TITLE_TAG_FALLBACK, **system_arguments, &block|
+        raise ArgumentError, "Title must be a string" unless block.call.is_a?(String)
+
         system_arguments[:tag] = fetch_or_fallback(TITLE_TAG_OPTIONS, tag, TITLE_TAG_FALLBACK)
         system_arguments[:font_size] ||= 3
         system_arguments[:mr] ||= 2
@@ -26,6 +28,8 @@ module Primer
       #
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :caption, lambda { |**system_arguments, &block|
+        raise ArgumentError, "Caption must be a string" unless block.call.is_a?(String)
+
         system_arguments[:color] ||= :subtle
         system_arguments[:mr] ||= 2
         system_arguments[:display] ||= [:none, :block]
@@ -36,7 +40,9 @@ module Primer
       # Optional right-side content
       #
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      renders_one :additional_information, lambda { |**system_arguments|
+      renders_one :additional_information, lambda { |**system_arguments, &block|
+        raise ArgumentError, "The additional information must be a string" unless block.call.is_a?(String)
+
         Primer::BaseComponent.new(tag: :div, **system_arguments)
       }
 

--- a/previews/primer/open_project/border_box/collapsible_header_preview/playground.html.erb
+++ b/previews/primer/open_project/border_box/collapsible_header_preview/playground.html.erb
@@ -4,7 +4,7 @@
                                                                      collapsed: collapsed)) do |header| %>
       <% header.with_title { title } %>
       <% header.with_count(count: count) %>
-      <% header.with_description { description } %>
+      <% header.with_description { description } unless description.nil? %>
     <% end %>
   <% end %>
   <% component.with_body { "Body" } %>

--- a/test/components/primer/open_project/border_box/collapsible_header_test.rb
+++ b/test/components/primer/open_project/border_box/collapsible_header_test.rb
@@ -39,6 +39,16 @@ class Primer::OpenProject::BorderBox::CollapsibleHeaderTest < Minitest::Test
     assert_equal "Title must be present", err.message
   end
 
+  def test_does_not_render_when_title_is_not_a_string
+    err = assert_raises ArgumentError do
+      render_inline(Primer::OpenProject::BorderBox::CollapsibleHeader.new(box: Primer::Beta::BorderBox.new)) do |header|
+        header.with_title { { name: "Test title" } }
+      end
+    end
+
+    assert_equal "Title must be a string", err.message
+  end
+
   def test_renders_with_description
     render_preview(:with_description)
 

--- a/test/components/primer/open_project/collapsible_section_test.rb
+++ b/test/components/primer/open_project/collapsible_section_test.rb
@@ -24,6 +24,17 @@ class PrimerOpenProjectCollapsibleSectionTest < Minitest::Test
     assert_equal "Title must be present", err.message
   end
 
+  def test_does_not_render_when_title_is_not_a_string
+    err = assert_raises ArgumentError do
+      render_inline(Primer::OpenProject::CollapsibleSection.new) do |component|
+        component.with_title { { name: "Hello" } }
+        component.with_collapsible_content { "HIDE ME" }
+      end
+    end
+
+    assert_equal "Title must be a string", err.message
+  end
+
   def test_does_not_render_without_content
     err = assert_raises ArgumentError do
       render_inline(Primer::OpenProject::CollapsibleSection.new) do |component|


### PR DESCRIPTION
### What are you trying to accomplish?
Enforce title for CollapsibleSection and CollapsibleHeader to be a String

#### List the issues that this change affects.
https://community.openproject.org/projects/design-system/work_packages/64149/activity

