### PR TITLE
[64228] Home screen widgets have the wrong headline tag

### DIFF
--- a/.changeset/good-snails-decide.md
+++ b/.changeset/good-snails-decide.md
@@ -1,0 +1,5 @@
+---
+"@openproject/primer-view-components": patch
+---
+
+set the fallback heading fallback to h2 in page header title

--- a/.playwright/screenshots/snapshots.test.ts-snapshots/primer/open_project/page_header/default/aria-snapshot.yml
+++ b/.playwright/screenshots/snapshots.test.ts-snapshots/primer/open_project/page_header/default/aria-snapshot.yml
@@ -6,5 +6,5 @@
       - link "Parent"
     - listitem:
       - link "Hello"
-- heading "Hello" [level=1]
+- heading "Hello" [level=2]
 - text: Last updated 5 minutes ago by XYZ.

--- a/app/components/primer/open_project/page_header/title.rb
+++ b/app/components/primer/open_project/page_header/title.rb
@@ -9,7 +9,7 @@ module Primer
         status :open_project
 
         HEADING_TAG_OPTIONS = [:h1, :h2, :h3, :h4, :h5, :h6].freeze
-        HEADING_TAG_FALLBACK = :h1
+        HEADING_TAG_FALLBACK = :h2
 
         renders_one :editable_form, lambda { |model: false, update_path:, cancel_path:, input_name: :title, method: :put, label: I18n.t(:label_title), placeholder: I18n.t(:label_title), **system_arguments|
           primer_form_with(


### PR DESCRIPTION
### What are you trying to accomplish?
Set the page header tag to h2

Closes https://community.openproject.org/wp/64228

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.