### PR TITLE
Allow specifying a custom `menu_id:` for `ActionMenu` sub menus

### DIFF
--- a/app/components/primer/alpha/action_menu/sub_menu.rb
+++ b/app/components/primer/alpha/action_menu/sub_menu.rb
@@ -47,7 +47,7 @@ module Primer
         # @param overlay_arguments [Hash] Arguments to pass to the underlying <%= link_to_component(Primer::Alpha::Overlay) %>
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>.
         def initialize(
-          menu_id:,
+          menu_id: self.class.generate_id,
           anchor_align: DEFAULT_ANCHOR_ALIGN,
           anchor_side: DEFAULT_ANCHOR_SIDE,
           overlay_arguments: {},

--- a/app/components/primer/alpha/action_menu/sub_menu_item.rb
+++ b/app/components/primer/alpha/action_menu/sub_menu_item.rb
@@ -11,10 +11,9 @@ module Primer
           # ActionList::Item base class or to the SubMenu instance. Doing so prevents a form
           # input from being emitted for sub-menu items, which prevents an extra empty value
           # from being sent to the server on form submit.
-          @menu_id = self.class.generate_id
           @sub_menu = SubMenu.allocate
-          system_arguments = @sub_menu.send(:initialize, **system_arguments, menu_id: @menu_id)
-          system_arguments[:id] = "#{@menu_id}-button"
+          system_arguments = @sub_menu.send(:initialize, **system_arguments)
+          system_arguments[:id] = "#{@sub_menu.menu_id}-button"
 
           @form_arguments = form_arguments
 

--- a/test/components/alpha/action_menu_test.rb
+++ b/test/components/alpha/action_menu_test.rb
@@ -25,7 +25,20 @@ module Primer
           menu.assert_selector("ul[id='menu-1-list'][aria-labelledby='menu-1-button'][role='menu']", visible: false) do |ul|
             ul.assert_selector("li button[role='menuitem']", visible: false)
           end
+          menu.assert_selector("anchored-position[id='menu-1-overlay'][anchor=menu-1-button]")
         end
+      end
+
+      def test_accepts_custom_menu_id_for_sub_menus
+        render_inline(Primer::Alpha::ActionMenu.new) do |component|
+          component.with_sub_menu_item(label: "Sub-menu", menu_id: "foobarbaz") do |sub_menu|
+            sub_menu.with_item(label: "Hello, world")
+          end
+        end
+
+        assert_selector("button[id='foobarbaz-button'][aria-haspopup='true']", text: "Sub-menu")
+        assert_selector("ul[id='foobarbaz-list'][aria-labelledby='foobarbaz-button'][role='menu']", visible: false)
+        assert_selector("anchored-position[id='foobarbaz-overlay'][anchor=foobarbaz-button]")
       end
 
       def test_falls_back_to_button_if_disallowed_tag_is_given


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Due to an oversight in the recently merged multi-level `ActionMenu` code, the `menu_id:` argument to a sub-menu would be ignored, and a random ID used instead. This PR addresses the problem and allows for custom `menu_id`s.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

The `menu_id` is accepted by the `ActionMenu::Menu` class, and a random one is generated if no custom ID is provided. In the old code, the `SubMenuItem` code incorrectly hard-coded a random ID instead of delegating that responsibility to the `Menu` class. The solution in this PR was to remove this hard-coded ID and rely instead on the existing logic inside `Menu`'s constructor.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
