### PR TITLE
enable sub menu in sub header action menu

### DIFF
--- a/.changeset/fair-cloths-guess.md
+++ b/.changeset/fair-cloths-guess.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': minor
+---
+
+Enable sub menus in sub header action menus

--- a/app/components/primer/open_project/sub_header/menu.rb
+++ b/app/components/primer/open_project/sub_header/menu.rb
@@ -46,7 +46,7 @@ module Primer
         @menu = Primer::Alpha::ActionMenu.new(**system_arguments)
       end
 
-      delegate :with_item, :with_divider, :with_avatar_item, :with_group,
+      delegate :with_item, :with_divider, :with_avatar_item, :with_group, :with_sub_menu_item,
                to: :@menu
 
       def before_render


### PR DESCRIPTION

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

A vanilla `Primer::Alpha::ActionMenu` allows adding sub menus via the `sub_menu_item` slot. `Primer::OpenProject::SubHeader::Menu` wraps that original ActionMenu but as of now, does not delegate the call to add sub menus.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

Adding the method call to the ones delegated to the `@menu` instance variable of a `Primer::OpenProject::SubHeader::Menu` instance.
