### PR TITLE
[64802] Add support for TabPanels in PageHeader

### DIFF
--- a/.changeset/slow-parks-grin.md
+++ b/.changeset/slow-parks-grin.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': minor
+---
+
+Add support for TabPanels to Primer::OpenProject::PageHeader

--- a/app/components/primer/open_project/page_header.html.erb
+++ b/app/components/primer/open_project/page_header.html.erb
@@ -30,9 +30,9 @@
   </div>
 
   <%= description %>
-  <% if tab_nav %>
+  <% if tabs %>
     <div class="PageHeader-tabNavBar">
-      <%= tab_nav %>
+      <%= tabs %>
     </div>
   <% end %>
 <% end %>

--- a/app/components/primer/open_project/page_header.rb
+++ b/app/components/primer/open_project/page_header.rb
@@ -220,14 +220,23 @@ module Primer
       # Optional tabs nav at the bottom of the page header
       #
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      renders_one :tab_nav, lambda { |**system_arguments, &block|
-        @system_arguments[:classes] = class_names(@system_arguments[:classes], "PageHeader--withTabNav")
+      renders_one :tabs, types: {
+        nav: {
+          renders: lambda { |**system_arguments, &block|
+            tab_navigation_options(**system_arguments)
 
-        system_arguments = deny_tag_argument(**system_arguments)
-        system_arguments[:tag] = :div
-        system_arguments[:classes] = class_names(system_arguments[:classes], "PageHeader-tabNav")
+            Primer::Alpha::TabNav.new(**system_arguments, &block)
+          },
+          as: :tab_nav
+        },
+        panels: {
+          renders: lambda { |**system_arguments, &block|
+            tab_navigation_options(**system_arguments)
 
-        Primer::Alpha::TabNav.new(**system_arguments, &block)
+            Primer::Alpha::TabPanels.new(**system_arguments, &block)
+          },
+          as: :tab_panels
+        },
       }
 
       # @param mobile_menu_label [String] The tooltip label of the mobile menu
@@ -327,6 +336,14 @@ module Primer
           @mobile_action = component.new(**system_arguments.deep_merge(mobile_options))
           @mobile_action_block = block
         end
+      end
+
+      def tab_navigation_options(**system_arguments)
+        @system_arguments[:classes] = class_names(@system_arguments[:classes], "PageHeader--withTabNav")
+
+        system_arguments = deny_tag_argument(**system_arguments)
+        system_arguments[:tag] = :div
+        system_arguments[:classes] = class_names(system_arguments[:classes], "PageHeader-tabNav")
       end
     end
   end

--- a/previews/primer/open_project/page_header_preview.rb
+++ b/previews/primer/open_project/page_header_preview.rb
@@ -208,6 +208,24 @@ module Primer
         end
       end
 
+      # @label With tab panels
+      #
+      def tab_panels
+        render(Primer::OpenProject::PageHeader.new) do |header|
+          header.with_title { "Hello" }
+          header.with_breadcrumbs([{ href: "/foo", text: "Foo" }, { href: "/bar", text: "Bar" }, "Baz"])
+          header.with_description { "Last updated 5 minutes ago by XYZ." }
+          header.with_tab_panels(label: "label") do |panels|
+            Array.new(3) do |i|
+              panels.with_tab(selected: i.zero?, id: "tab-#{i + 1}") do |tab|
+                tab.with_panel { "Panel #{i + 1}" }
+                tab.with_text { "Tab #{i + 1}" }
+              end
+            end
+          end
+        end
+      end
+
       # @label With a SegmentedControl
       def segmented_control
         render(Primer::OpenProject::PageHeader.new) do |component|

--- a/test/components/primer/open_project/page_header_test.rb
+++ b/test/components/primer/open_project/page_header_test.rb
@@ -234,6 +234,26 @@ class PrimerOpenProjectPageHeaderTest < Minitest::Test
     assert_selector(".PageHeader-tabNav .tabnav-tab")
   end
 
+  def test_renders_tab_panels
+    render_inline(Primer::OpenProject::PageHeader.new) do |header|
+      header.with_title { "Hello" }
+      header.with_breadcrumbs(breadcrumb_elements)
+      header.with_tab_panels(label: "label") do |nav|
+        Array.new(3) do |i|
+          panels.with_tab(selected: i.zero?, id: "tab-#{i + 1}") do |tab|
+            tab.with_panel { "Panel #{i + 1}" }
+            tab.with_text { "Tab #{i + 1}" }
+          end
+        end
+      end
+    end
+
+    assert_selector(".PageHeader.PageHeader--withTabNav")
+    assert_selector(".PageHeader-tabNavBar")
+    assert_selector(".PageHeader-tabNav")
+    assert_selector(".PageHeader-tabNav #panel-tab-1", text: "Panel 1")
+  end
+
   def test_renders_segmented_control
     render_inline(Primer::OpenProject::PageHeader.new) do |header|
       header.with_title { "Hello" }


### PR DESCRIPTION
### What are you trying to accomplish?
Add a slot for`Primer::Alpha::TabPanels` in PageHeader

### Screenshots
<img width="551" alt="Bildschirmfoto 2025-06-18 um 16 29 05" src="https://github.com/user-attachments/assets/7daa2190-1acc-4b58-9ac0-3d75d07f56ea" />

#### List the issues that this change affects.

https://community.openproject.org/wp/64802


