### PR TITLE
`script/merge-upstream` workflow fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,3 @@ Gemfile.lock merge=ours
 demo/Gemfile.lock merge=ours
 lib/primer/view_components/version.rb merge=ours
 package-lock.json merge=ours
-package.json merge=ours

--- a/script/merge-upstream
+++ b/script/merge-upstream
@@ -21,6 +21,8 @@ git reset --hard origin/main
 git merge bump/primer-upstream-ref --no-commit
 
 find .changeset/ -name "*.md" -exec $SED -i "s/\@primer\/view-components/\@openproject\/primer-view-components/g" {} +
-
 git add .changeset/
+
+./setup
+git add */Gemfile.lock */package-lock.json
 git commit


### PR DESCRIPTION

## Overview

* Removes customised merge driver for `package.json` from `.gitattributes`.
* Updates `/script/merge-upstream` to re-run `./setup` (`bundle install` `npm install`).
* Commits updated `Gemfile.lock` and `package-lock.json`.
