### PR TITLE
[63777] Add option to skip indiviual items from mobile breadcrumb behaviour

### DIFF
--- a/.changeset/purple-paths-look.md
+++ b/.changeset/purple-paths-look.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Add the option to skip breadcrumb items for mobile

--- a/app/components/primer/open_project/page_header.rb
+++ b/app/components/primer/open_project/page_header.rb
@@ -186,11 +186,16 @@ module Primer
         system_arguments[:classes] = class_names(system_arguments[:classes], "PageHeader-breadcrumbs")
         system_arguments[:display] ||= DEFAULT_BREADCRUMBS_DISPLAY
 
-        # show parent link if there is a parent for current page
-        if items.length > 1
-          link_arguments = {}
-          parent_item = items[items.length - 2]
+        parent_item = nil
 
+        # show parent link if there is a parent for current page
+        items.reverse_each do |item|
+          parent_item = item if item.is_a?(Hash) && item[:skip_for_mobile] != true
+          break if parent_item.present?
+        end
+
+        if parent_item.present? && parent_item[:href].present?
+          link_arguments = {}
           link_arguments[:icon] = fetch_or_fallback(BACK_BUTTON_ICON_OPTIONS, DEFAULT_BACK_BUTTON_ICON)
           link_arguments[:href] = parent_item[:href]
           link_arguments[:target] = "_top"

--- a/previews/primer/open_project/page_header_preview.rb
+++ b/previews/primer/open_project/page_header_preview.rb
@@ -256,6 +256,16 @@ module Primer
           end
         end
       end
+
+      # @label With skipable breadcrumb items
+      def skip_breadcrumb_item
+        render(Primer::OpenProject::PageHeader.new) do |component|
+          component.with_title { "Resize me to mobile screen size" }
+          component.with_breadcrumbs([{ href: "/foo", text: "Foo" },
+                                      { href: "/bar", text: "Bar", skip_for_mobile: true },
+                                       "Baz"])
+        end
+      end
     end
   end
 end

--- a/test/components/primer/open_project/page_header_test.rb
+++ b/test/components/primer/open_project/page_header_test.rb
@@ -269,6 +269,27 @@ class PrimerOpenProjectPageHeaderTest < Minitest::Test
     assert_selector(".FormField-input.Button--secondary")
   end
 
+  def test_skips_a_breadcrumb_item_for_mobile
+    render_inline(Primer::OpenProject::PageHeader.new) do |header|
+      header.with_title { "Hello" }
+      header.with_breadcrumbs([{ href: "/foo", text: "Foo" },
+                               { href: "/bar", text: "Bar", skip_for_mobile: true },
+                               "Baz"])
+    end
+
+    assert_text("Hello")
+    assert_selector(".PageHeader-title")
+    assert_selector(".PageHeader-breadcrumbs")
+
+    # The direct parent is skipped for the mobile back button..
+    assert_selector("a.PageHeader-parentLink[href='/foo']")
+
+    # .. but it is present in the normal desktop
+    assert_selector("nav[aria-label='Breadcrumb'].PageHeader-breadcrumbs .breadcrumb-item a[href='/foo']")
+    assert_selector("nav[aria-label='Breadcrumb'].PageHeader-breadcrumbs .breadcrumb-item a[href='/bar']")
+    assert_selector("nav[aria-label='Breadcrumb'].PageHeader-breadcrumbs .breadcrumb-item.text-bold a[href='#']")
+  end
+
   private
 
   def breadcrumb_elements


### PR DESCRIPTION
### What are you trying to accomplish?
Add option to skip breadcrumb items for mobile

### Integration
No

#### List the issues that this change affects.
https://community.openproject.org/wp/63777

#### Risk Assessment
- [x] **Low risk** the change is small, highly observable, and easily rolled back.

### What approach did you choose and why?
We considered two approaches:

1. Let the caller define the mobile back button explicitly (e.g via a separate slot). This was rejected, because we for one cannot control, that whatever people enter there matches our expectations of the mobile breadcrumb. Second, the default is still that the back button is build based on the breadcrumb. We wanted to keep that behaviour.
2. We exlude individal items from being considered for the mobile link. Thus, we keeo control over the consistencies between desktop and mobile and have a solution that only affects those exceptions, where the direct parent is not the one to be chosen for the mobile link.

