### PR TITLE
[62820] Primer Alpha::ToggleSwitch locale support

### DIFF
--- a/app/components/primer/alpha/toggle_switch.html.erb
+++ b/app/components/primer/alpha/toggle_switch.html.erb
@@ -4,8 +4,8 @@
     <%= render(Primer::Beta::Spinner.new(size: :small, hidden: "true", data: { target: "toggle-switch.loadingSpinner" })) %>
   </span>
   <%= render(Primer::Beta::Text.new(aria: { hidden: true }, classes: "ToggleSwitch-status")) do %>
-    <%= render(Primer::Box.new(classes: "ToggleSwitch-statusOn").with_content("On")) %>
-    <%= render(Primer::Box.new(classes: "ToggleSwitch-statusOff").with_content("Off")) %>
+    <%= render(Primer::Box.new(classes: "ToggleSwitch-statusOn").with_content(@on_label)) %>
+    <%= render(Primer::Box.new(classes: "ToggleSwitch-statusOff").with_content(@off_label)) %>
   <% end %>
 
   <%= render(Primer::BaseComponent.new(tag: :button, classes: "ToggleSwitch-track", disabled: disabled?, data: { target: "toggle-switch.switch", action: "click:toggle-switch#toggle" }, **@button_arguments)) do %>

--- a/app/components/primer/alpha/toggle_switch.rb
+++ b/app/components/primer/alpha/toggle_switch.rb
@@ -28,6 +28,8 @@ module Primer
       # @param status_label_position [Symbol] Which side of the toggle switch to render the status label. <%= one_of(Primer::Alpha::ToggleSwitch::STATUS_LABEL_POSITION_OPTIONS) %>
       # @param turbo [Boolean] Whether or not to request a turbo stream and render the response as such.
       # @param autofocus [Boolean] Whether switch should be autofocused when rendered.
+      # @param on_label [String] Custom label to show when switch is ON. Defaults to I18n.t("label_switch.on").
+      # @param off_label [String] Custom label to show when switch is OFF. Defaults to I18n.t("label_switch.off").
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(
         src: nil,
@@ -38,6 +40,8 @@ module Primer
         status_label_position: STATUS_LABEL_POSITION_DEFAULT,
         turbo: false,
         autofocus: nil,
+        on_label: nil,
+        off_label: nil,
         **system_arguments
       )
         @src = src
@@ -70,6 +74,9 @@ module Primer
         @button_arguments[:autofocus] = true if autofocus
 
         @system_arguments[:src] = @src if @src
+
+        @on_label  = on_label  || "On"
+        @off_label = off_label || "Off"
       end
 
       def on?

--- a/previews/primer/alpha/toggle_switch_preview.rb
+++ b/previews/primer/alpha/toggle_switch_preview.rb
@@ -66,6 +66,10 @@ module Primer
       def with_autofocus
         render(Primer::Alpha::ToggleSwitch.new(src: UrlHelpers.primer_view_components.toggle_switch_index_path, autofocus: true))
       end
+
+      def with_custom_label
+        render Primer::Alpha::ToggleSwitch.new(src: UrlHelpers.primer_view_components.toggle_switch_index_path, on_label: "Enabled", off_label: "Disabled")
+      end
     end
   end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
Pass on and off labels to the Primer toggle switch, so it can receive locale

### Screenshots
<img width="700" height="384" alt="Screenshot 2025-08-25 at 17 12 24" src="https://github.com/user-attachments/assets/4614ad3a-e28c-4f0d-a329-9dd0edfde49b" />

### Integration
We have to raise it in upstream repository as an issue.

Closes https://community.openproject.org/wp/62820

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
Pass two strings as the labels for on and off states in toggle switch.

