### PR TITLE
[61890] Advanced accessibility for the Danger Dialogs (with ARIA semantics to communicate contextual changes)

### DIFF
--- a/app/components/primer/open_project/danger_dialog.html.erb
+++ b/app/components/primer/open_project/danger_dialog.html.erb
@@ -3,7 +3,10 @@
     <% dialog.with_header(close_label: I18n.t("button_close")) %>
   <% end %>
 
-  <danger-dialog-form-helper>
+  <danger-dialog-form-helper
+    data-confirmation-live-message-checked="<%= @confirmation_live_message_checked %>"
+    data-confirmation-live-message-unchecked="<%= @confirmation_live_message_unchecked %>">
+
     <%= render(@form_wrapper) do %>
       <scrollable-region data-labelled-by="<%= labelledby %>">
         <%= render(Primer::Alpha::Dialog::Body.new) do %>
@@ -15,9 +18,26 @@
         <% end %>
       </scrollable-region>
       <%= render(Primer::Alpha::Dialog::Footer.new(show_divider: false)) do %>
-        <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": dialog_id })) { @cancel_button_text } %>
-        <%= render(Primer::Beta::Button.new(type: (@form_wrapper.shows_form? ? :submit : :button), scheme: :danger, aria: { describedby: "#{dialog_id}-check_box" }, data: { "submit-dialog-id": dialog_id })) { @confirm_button_text } %>
+        <%= render(Primer::Beta::Button.new(
+          data: { "close-dialog-id": dialog_id }
+        )) { @cancel_button_text } %>
+
+        <%= render(Primer::Beta::Button.new(
+          type: (@form_wrapper.shows_form? ? :submit : :button),
+          scheme: :danger,
+          disabled: true,
+          aria: { describedby: "#{dialog_id}-check_box" },
+          data: {
+            "submit-dialog-id": dialog_id,
+            target: "danger-dialog-form-helper.submitButton"
+          }
+        )) { @confirm_button_text } %>
       <% end %>
+
+      <div class="sr-only"
+           aria-live="assertive"
+           aria-atomic="true"
+           data-target="danger-dialog-form-helper.liveRegion"></div>
     <% end %>
   </danger-dialog-form-helper>
 <% end %>

--- a/app/components/primer/open_project/danger_dialog.html.erb
+++ b/app/components/primer/open_project/danger_dialog.html.erb
@@ -17,23 +17,8 @@
           <%= confirmation_check_box %>
         <% end %>
       </scrollable-region>
-      <%= render(Primer::Alpha::Dialog::Footer.new(show_divider: false)) do %>
-        <%= render(Primer::Beta::Button.new(
-          data: { "close-dialog-id": dialog_id }
-        )) { @cancel_button_text } %>
-
-        <%= render(Primer::Beta::Button.new(
-          type: (@form_wrapper.shows_form? ? :submit : :button),
-          scheme: :danger,
-          disabled: true,
-          aria: { describedby: "#{dialog_id}-check_box" },
-          data: {
-            "submit-dialog-id": dialog_id,
-            target: "danger-dialog-form-helper.submitButton"
-          }
-        )) { @confirm_button_text } %>
-      <% end %>
-
+      <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": dialog_id })) { @cancel_button_text } %>
+      <%= render(Primer::Beta::Button.new(type: (@form_wrapper.shows_form? ? :submit : :button), scheme: :danger, aria: { describedby: "#{dialog_id}-check_box" }, data: { "submit-dialog-id": dialog_id })) { @confirm_button_text } %>
       <div class="sr-only"
            aria-live="assertive"
            aria-atomic="true"

--- a/app/components/primer/open_project/danger_dialog.html.erb
+++ b/app/components/primer/open_project/danger_dialog.html.erb
@@ -16,7 +16,7 @@
       </scrollable-region>
       <%= render(Primer::Alpha::Dialog::Footer.new(show_divider: false)) do %>
         <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": dialog_id })) { @cancel_button_text } %>
-        <%= render(Primer::Beta::Button.new(type: (@form_wrapper.shows_form? ? :submit : :button), scheme: :danger, data: { "submit-dialog-id": dialog_id })) { @confirm_button_text } %>
+        <%= render(Primer::Beta::Button.new(type: (@form_wrapper.shows_form? ? :submit : :button), scheme: :danger, aria: { describedby: "#{dialog_id}-check_box" }, data: { "submit-dialog-id": dialog_id })) { @confirm_button_text } %>
       <% end %>
     <% end %>
   </danger-dialog-form-helper>

--- a/app/components/primer/open_project/danger_dialog.rb
+++ b/app/components/primer/open_project/danger_dialog.rb
@@ -65,6 +65,8 @@ module Primer
       # @param form_arguments [Hash] Allows the dialog to submit a form. Pass EITHER the `builder:` option to this hash to reuse an existing Rails form, or `action:` if you prefer the component to render the form tag itself. `builder:` should be an instance of `ActionView::Helpers::FormBuilder`, which is created by the standard Rails `#form_with` and `#form_for` helpers. The `name:` option is the desired name of the field that will be included in the params sent to the server on form submission.
       # @param id [String] The id of the dialog.
       # @param title [String] The title of the dialog. Although visually hidden, a label is rendered for assistive technologies.
+      # @param confirmation_live_message_checked [String] The message announced to assistive technologies when the confirmation checkbox is checked. Defaults to "Confirmation checkbox checked. You can now proceed."
+      # @param confirmation_live_message_unchecked [String] The message announced to assistive technologies when the confirmation checkbox is unchecked. Defaults to "Please check the confirmation box to proceed."
       # @param confirm_button_text [String] The text of the confirm button. Will default to `I18n.t("button_delete")`, or `I18n.t("button_delete_permanently")` if `confirmation_check_box` slot has been passed to the component.
       # @param cancel_button_text [String] The text of the cancel button. Will default to `I18n.t("button_cancel")`.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
@@ -74,6 +76,8 @@ module Primer
         title:,
         confirm_button_text: nil,
         cancel_button_text: nil,
+        confirmation_live_message_checked: "Confirmation checkbox checked. You can now proceed.",
+        confirmation_live_message_unchecked: "Please check the confirmation box to proceed.",
         **system_arguments
       )
         @check_box_name = form_arguments.delete(:name) || "confirm_dangerous_action"
@@ -82,6 +86,9 @@ module Primer
 
         @confirm_button_text = confirm_button_text
         @cancel_button_text = cancel_button_text
+
+        @confirmation_live_message_checked = confirmation_live_message_checked
+        @confirmation_live_message_unchecked = confirmation_live_message_unchecked
 
         deny_single_argument(:role, "`role` will always be set to `alertdialog`.", **system_arguments)
 

--- a/app/components/primer/open_project/danger_dialog_form_helper.ts
+++ b/app/components/primer/open_project/danger_dialog_form_helper.ts
@@ -5,6 +5,7 @@ const SUBMIT_BUTTON_SELECTOR = 'input[type=submit],button[type=submit],button[da
 @controller
 class DangerDialogFormHelperElement extends HTMLElement {
   @target checkbox: HTMLInputElement | undefined
+  @target liveRegion: HTMLElement | undefined
 
   get form() {
     return this.querySelector('form')
@@ -25,8 +26,18 @@ class DangerDialogFormHelperElement extends HTMLElement {
   }
 
   toggle(): void {
-    if (this.checkbox) {
-      this.submitButton.disabled = !this.checkbox.checked
+    if (!this.checkbox || !this.submitButton) return
+
+    const enabled = this.checkbox.checked
+    this.submitButton.disabled = !enabled
+
+    if (this.liveRegion) {
+      const message = enabled
+          ? this.dataset.confirmationLiveMessageChecked
+          : this.dataset.confirmationLiveMessageUnchecked
+
+      this.liveRegion.textContent = ''
+      this.liveRegion!.textContent = message || ''
     }
   }
 

--- a/previews/primer/open_project/danger_dialog_preview.rb
+++ b/previews/primer/open_project/danger_dialog_preview.rb
@@ -123,7 +123,6 @@ module Primer
           dialog.with_confirmation_check_box_content("I understand that this deletion cannot be reversed")
         end
       end
-
     end
   end
 end

--- a/previews/primer/open_project/danger_dialog_preview.rb
+++ b/previews/primer/open_project/danger_dialog_preview.rb
@@ -40,6 +40,8 @@ module Primer
       # @param confirm_button_text [String]
       # @param cancel_button_text [String]
       # @param check_box_text [String]
+      # @param live_message_checked [String]
+      # @param live_message_unchecked [String]
       def playground(
         icon: :"alert",
         icon_color: :danger,
@@ -47,15 +49,23 @@ module Primer
         show_additional_details: false,
         confirm_button_text: "Understood",
         cancel_button_text: "NO!",
-        check_box_text: "I understand that this deletion cannot be reversed"
+        check_box_text: "I understand that this deletion cannot be reversed",
+        live_message_checked: "Checkbox checked — you can proceed.",
+        live_message_unchecked: "Please check the confirmation box to continue."
       )
-        render_with_template(locals: { icon: icon,
-                                       icon_color: icon_color,
-                                       show_description: show_description,
-                                       show_additional_details: show_additional_details,
-                                       confirm_button_text: confirm_button_text,
-                                       cancel_button_text: cancel_button_text,
-                                       check_box_text: check_box_text })
+        render_with_template(
+          locals: {
+            icon: icon,
+            icon_color: icon_color,
+            show_description: show_description,
+            show_additional_details: show_additional_details,
+            confirm_button_text: confirm_button_text,
+            cancel_button_text: cancel_button_text,
+            check_box_text: check_box_text,
+            live_message_checked: live_message_checked,
+            live_message_unchecked: live_message_unchecked
+          }
+        )
       end
 
       # @label With form using FormBuilder
@@ -96,6 +106,24 @@ module Primer
       def with_form_test(route_format: :html)
         render_with_template(locals: { route_format: route_format })
       end
+
+      # @label With confirmation checkbox and custom live messages
+      # @snapshot interactive
+      def with_confirmation_check_box_and_live_messages
+        render(Primer::OpenProject::DangerDialog.new(
+          title: "Delete dialog",
+          confirmation_live_message_checked: "You checked the box — deletion is now possible.",
+          confirmation_live_message_unchecked: "You must check the box to enable deletion."
+        )) do |dialog|
+          dialog.with_show_button { "Click me" }
+          dialog.with_confirmation_message do |message|
+            message.with_heading(tag: :h2) { "Permanently delete this item?" }
+            message.with_description_content("This action is irreversible. Proceed with caution.")
+          end
+          dialog.with_confirmation_check_box_content("I understand that this deletion cannot be reversed")
+        end
+      end
+
     end
   end
 end

--- a/test/components/primer/open_project/danger_dialog_test.rb
+++ b/test/components/primer/open_project/danger_dialog_test.rb
@@ -282,4 +282,24 @@ class PrimerOpenProjectDangerDialogTest < Minitest::Test
       assert_selector(".DangerDialog-additionalDetails", text: "Additional important information.")
     end
   end
+
+  def test_renders_live_region_for_confirmation_checkbox
+    render_inline(Primer::OpenProject::DangerDialog.new(
+      title: "Danger confirmation action",
+      confirmation_live_message_checked: "Checkbox checked — you can proceed.",
+      confirmation_live_message_unchecked: "Please check the confirmation box to continue."
+    )) do |dialog|
+      dialog.with_confirmation_message do |message|
+        message.with_heading(tag: :h2) { "Danger" }
+      end
+      dialog.with_confirmation_check_box { "I confirm this deletion" }
+    end
+
+    # Check that the live region exists and is sr-only
+    assert_selector("div.sr-only[data-target='danger-dialog-form-helper.liveRegion']")
+
+    live_region = page.find_css("div.sr-only[data-target='danger-dialog-form-helper.liveRegion']").first
+    assert_equal "assertive", live_region.attributes["aria-live"].value
+    assert_equal "true", live_region.attributes["aria-atomic"].value
+  end
 end

--- a/test/system/open_project/danger_dialog_test.rb
+++ b/test/system/open_project/danger_dialog_test.rb
@@ -81,4 +81,31 @@ class IntegrationOpenProjectDangerDialogTest < System::TestCase
     assert_equal "Superfluous", form_params["reason"]
     assert_equal ["creator", "assignee"], form_params["notify"]
   end
+
+  def test_live_region_updates_based_on_checkbox
+    visit_preview(:with_confirmation_check_box)
+
+    click_button("Click me")
+
+    assert_selector(".DangerDialog") do
+      live_region = find("[data-target='danger-dialog-form-helper.liveRegion']")
+
+      # Initially, checkbox is unchecked
+      assert_equal "Please check the confirmation box to proceed.", live_region.text
+
+      within(".DangerDialog") do
+        # Check the checkbox
+        check("I understand that this deletion cannot be reversed")
+      end
+
+      # Live region updates when checked
+      assert_equal "Confirmation checkbox checked. You can now proceed.", live_region.text
+
+      # Uncheck to verify it toggles back
+      within(".DangerDialog") do
+        uncheck("I understand that this deletion cannot be reversed")
+      end
+      assert_equal "Please check the confirmation box to proceed.", live_region.text
+    end
+  end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
Improve accessibility for danger dialog


Closes https://community.openproject.org/wp/61890

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
I chose to implement this feature as a two-step confirmation flow with a required checkbox before enabling the destructive action button. The button is associated with the checkbox via aria-describedby, and a live region communicates state changes to assistive technologies.

This approach was chosen because:

It prevents accidental destructive actions by requiring explicit user confirmation.

aria-describedby provides a semantic, persistent relationship between the checkbox and the confirm button.

The live region ensures screen reader users receive timely feedback when the confirmation state changes.

It keeps the dialog experience consistent while improving safety, accessibility, and clarity for all users.

