### PR TITLE
[67625] Page header tab nav is broken in combination with items page and page header description

### DIFF
--- a/.changeset/thin-teams-invent.md
+++ b/.changeset/thin-teams-invent.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Avoid increasing description of PageHeader

--- a/app/components/primer/open_project/page_header.pcss
+++ b/app/components/primer/open_project/page_header.pcss
@@ -44,7 +44,7 @@
 .PageHeader-description {
   font-size: var(--text-body-size-medium);
   color: var(--fgColor-muted);
-  flex: 1 100%;
+  flex: 1 auto;
 }
 
 .PageHeader-description--underlined-links a {


### PR DESCRIPTION
### What are you trying to accomplish?
Avoid increasing PageHeader description

#### List the issues that this change affects.
https://community.openproject.org/wp/67625
