### PR TITLE
Support dynamic labels for multiple variant `ActionMenu`

### DIFF
--- a/.changeset/sweet-candies-pay.md
+++ b/.changeset/sweet-candies-pay.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': minor
+---
+
+Support dynamic labels for ActionMenu multiple select variant

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -455,6 +455,8 @@ export class ActionMenuElement extends HTMLElement {
     } else {
       // multi-select mode allows unchecking a checked item
       item.setAttribute('aria-checked', `${checked}`)
+
+      this.#setDynamicLabel()
     }
 
     this.#updateInput()
@@ -497,18 +499,25 @@ export class ActionMenuElement extends HTMLElement {
   }
 
   #setDynamicLabel() {
-    if (this.selectVariant !== 'single') return
     if (!this.dynamicLabel) return
     const invokerLabel = this.invokerLabel
     if (!invokerLabel) return
     this.#originalLabel ||= invokerLabel.textContent || ''
-    const itemLabel = this.querySelector('[aria-checked=true] .ActionListItem-label')
+    let itemLabel: string | undefined
+    if (this.selectVariant === 'single') {
+      itemLabel = this.querySelector('[aria-checked=true] .ActionListItem-label')?.textContent
+    } else if (this.selectVariant === 'multiple') {
+      itemLabel = Array.from(this.querySelectorAll(`[aria-checked=true] .ActionListItem-label`))
+        .map(label => label.textContent.trim())
+        .join(', ')
+    }
+    itemLabel ||= this.#originalLabel
     if (itemLabel && this.dynamicLabel) {
       const prefixSpan = document.createElement('span')
       prefixSpan.classList.add('color-fg-muted')
       const contentSpan = document.createElement('span')
       prefixSpan.textContent = this.dynamicLabelPrefix
-      contentSpan.textContent = itemLabel.textContent || ''
+      contentSpan.textContent = itemLabel
       invokerLabel.replaceChildren(prefixSpan, contentSpan)
     } else {
       invokerLabel.textContent = this.#originalLabel

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -516,7 +516,7 @@ export class ActionMenuElement extends HTMLElement {
       const prefixSpan = document.createElement('span')
       prefixSpan.classList.add('color-fg-muted')
       const contentSpan = document.createElement('span')
-      prefixSpan.textContent = this.dynamicLabelPrefix
+      prefixSpan.textContent = `${this.dynamicLabelPrefix} `
       contentSpan.textContent = itemLabel
       invokerLabel.replaceChildren(prefixSpan, contentSpan)
     } else {

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -505,10 +505,11 @@ export class ActionMenuElement extends HTMLElement {
     this.#originalLabel ||= invokerLabel.textContent || ''
     let itemLabel: string | undefined
     if (this.selectVariant === 'single') {
-      itemLabel = this.querySelector('[aria-checked=true] .ActionListItem-label')?.textContent
+      itemLabel = this.querySelector('[aria-checked=true] .ActionListItem-label')?.textContent?.trim()
     } else if (this.selectVariant === 'multiple') {
       itemLabel = Array.from(this.querySelectorAll(`[aria-checked=true] .ActionListItem-label`))
-        .map(label => label.textContent.trim())
+        .map(label => (label.textContent || '').trim())
+        .filter(Boolean)
         .join(', ')
     }
     itemLabel ||= this.#originalLabel
@@ -516,7 +517,7 @@ export class ActionMenuElement extends HTMLElement {
       const prefixSpan = document.createElement('span')
       prefixSpan.classList.add('color-fg-muted')
       const contentSpan = document.createElement('span')
-      prefixSpan.textContent = `${this.dynamicLabelPrefix} `
+      prefixSpan.textContent = this.dynamicLabelPrefix ? `${this.dynamicLabelPrefix} ` : ''
       contentSpan.textContent = itemLabel
       invokerLabel.replaceChildren(prefixSpan, contentSpan)
     } else {

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -794,9 +794,9 @@ module Alpha
       assert_equal %w[fast_forward ours Resolve], response["value"]
     end
 
-    def test_multiple_select_does_not_set_dynamic_label_for_preselected_item
+    def test_multiple_select_does_set_dynamic_label_for_preselected_item
       visit_preview(:multiple_select_form, route_format: :json)
-      assert_selector("action-menu[data-ready='true'] button[aria-controls]", exact_text: "Strategy")
+      assert_selector("action-menu[data-ready='true'] button[aria-controls]", exact_text: "Strategy: Ours")
     end
 
     def test_individual_items_can_submit_post_requests_via_forms

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -150,7 +150,7 @@ module Alpha
 
     ########## TESTS ############
 
-    def test_dynamic_labels
+    def test_dynamic_labels_for_single_select_variant
       visit_preview(:single_select_with_internal_label)
       assert_selector("action-menu button[aria-controls]", text: "Menu: Quote reply")
 
@@ -163,6 +163,22 @@ module Alpha
       click_on_first_item
 
       assert_selector("action-menu button[aria-controls]", text: "Menu")
+    end
+
+    def test_dynamic_labels_for_multiple_select_variant
+      visit_preview(:multiple_select_form, route_format: :json)
+      assert_selector("action-menu button[aria-controls]", text: "Strategy: Ours")
+
+      click_on_invoker_button
+      click_on_first_item
+      click_on_second_item
+
+      assert_selector("action-menu button[aria-controls]", text: "Strategy: Fast forward, Recursive, Ours")
+
+      click_on_invoker_button
+      click_on_first_item
+
+      assert_selector("action-menu button[aria-controls]", text: "Strategy: Recursive, Ours")
     end
 
     def test_anchor_align


### PR DESCRIPTION
> [!NOTE]
> This PR was recreated for the OPF fork from https://github.com/opf/primer_view_components/pull/465 


### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

### Screenshots

<img width="267" height="237" alt="image" src="https://github.com/user-attachments/assets/b8cc3e81-4288-47b7-b2e9-8c9d3aa8617d" />


### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.

Closes #3826

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
