### PR TITLE
[DREAM-729] Lazy loaded Action menu positioning is incorrect when opened at the bottom of the page.

### DIFF
--- a/.changeset/silly-lights-fall.md
+++ b/.changeset/silly-lights-fall.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Fix lazy loaded action-menu positioning when opened at the bottom of the page.

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -472,6 +472,7 @@ export class ActionMenuElement extends HTMLElement {
   #handleIncludeFragmentReplaced() {
     this.#firstItem?.focus()
     this.#softDisableItems()
+    this.overlay?.update()
 
     // async items have loaded, so component is ready
     this.setAttribute('data-ready', 'true')

--- a/app/controllers/primer/view_components/action_menu_controller.rb
+++ b/app/controllers/primer/view_components/action_menu_controller.rb
@@ -10,6 +10,7 @@ module Primer
       def landing; end
 
       def deferred
+        sleep params[:delay].to_f if params[:delay].present?
         render "primer/view_components/action_menu/deferred"
       end
 

--- a/previews/primer/alpha/action_menu_preview.rb
+++ b/previews/primer/alpha/action_menu_preview.rb
@@ -310,6 +310,13 @@ module Primer
         render_with_template(locals: { nest_in_sub_menu: nest_in_sub_menu })
       end
 
+      # @label With deferred content near the bottom of the viewport
+      #
+      # @hidden
+      def with_deferred_content_near_bottom_of_viewport
+        render_with_template
+      end
+
       # @label With deferred preloaded content
       #
       def with_deferred_preloaded_content

--- a/previews/primer/alpha/action_menu_preview/with_deferred_content_near_bottom_of_viewport.html.erb
+++ b/previews/primer/alpha/action_menu_preview/with_deferred_content_near_bottom_of_viewport.html.erb
@@ -1,0 +1,10 @@
+<%# The invoker is pinned near the bottom of the viewport, leaving enough room for the loading %>
+<%# spinner placeholder to fit below it but not enough for the full deferred content, reproducing %>
+<%# the scenario from DREAM-729. The `delay` param forces the fragment response to arrive after the %>
+<%# overlay has already been positioned using the placeholder's size, instead of racing the fetch %>
+<%# against the initial position calculation. %>
+<div style="position: fixed; bottom: 100px; right: 0;">
+  <%= render(Primer::Alpha::ActionMenu.new(menu_id: "deferred-bottom", src: primer_view_components.action_menu_deferred_path(delay: 0.3))) do |menu| %>
+    <% menu.with_show_button { "Menu with deferred content" } %>
+  <% end %>
+</div>

--- a/static/info_arch.json
+++ b/static/info_arch.json
@@ -1439,6 +1439,19 @@
         }
       },
       {
+        "preview_path": "primer/alpha/action_menu/with_deferred_content_near_bottom_of_viewport",
+        "name": "with_deferred_content_near_bottom_of_viewport",
+        "snapshot": "false",
+        "skip_rules": {
+          "wont_fix": [
+            "region"
+          ],
+          "will_fix": [
+            "color-contrast"
+          ]
+        }
+      },
+      {
         "preview_path": "primer/alpha/action_menu/with_deferred_preloaded_content",
         "name": "with_deferred_preloaded_content",
         "snapshot": "false",

--- a/static/previews.json
+++ b/static/previews.json
@@ -633,6 +633,19 @@
         }
       },
       {
+        "preview_path": "primer/alpha/action_menu/with_deferred_content_near_bottom_of_viewport",
+        "name": "with_deferred_content_near_bottom_of_viewport",
+        "snapshot": "false",
+        "skip_rules": {
+          "wont_fix": [
+            "region"
+          ],
+          "will_fix": [
+            "color-contrast"
+          ]
+        }
+      },
+      {
         "preview_path": "primer/alpha/action_menu/with_deferred_preloaded_content",
         "name": "with_deferred_preloaded_content",
         "snapshot": "false",

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -890,6 +890,17 @@ module Alpha
       assert_equal page.evaluate_script("document.activeElement").text, "Copy link"
     end
 
+    def test_deferred_loading_overlay_positioned_within_viewport
+      visit_preview(:with_deferred_content_near_bottom_of_viewport)
+      click_on_invoker_button
+
+      # Wait for lazy content to load
+      assert_selector "action-menu ul li", text: "Copy link"
+
+      overlay = find("anchored-position").native.node
+      assert overlay.in_viewport?, "Overlay should be positioned within the viewport after deferred content loads"
+    end
+
     def test_deferred_dialog_opens
       visit_preview(:with_deferred_content)
 


### PR DESCRIPTION
### Ticket
https://community.openproject.org/wp/DREAM-729

### What are you trying to accomplish?
When an ActionMenu with lazy-loaded content (src=) is opened near the bottom of the viewport, the overlay is not repositioning itself after the async menu finished loading. The overlay calculated its position on open (before the content existed), and never updated once the `include-fragment` replaced the placeholder with the menu response.

### Screenshots
<details><summary>Before</summary>
<p>

<img width="952" height="354" alt="Screenshot of the action-menu being cut off by the bottom of the page." src="https://github.com/user-attachments/assets/23ba91d4-831f-4cda-9dc4-7593c3d316ee" />


</p>
</details> 

<details><summary>After</summary>
<p>

<img width="936" height="354" alt="Screenshot of the action-menu displayed in the correct position when opened at the bottom of the page." src="https://github.com/user-attachments/assets/641e8bed-b7a2-490c-b8f0-6d444cf98a48" />


</p>
</details> 

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
The fix is to call `overlay.update()` inside `#handleIncludeFragmentReplaced()` so the `anchored-position` element position recalculates after the lazily loaded fragment is displayed.

### Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [X] Tested in Chrome
- [X] Tested in Firefox
- [X] Tested in Safari
- [ ] Tested in Edge