### PR TITLE
[DREAM-738] Add dynamic selection counter to SelectPanel

### DIFF
--- a/.changeset/select-panel-dynamic-counter.md
+++ b/.changeset/select-panel-dynamic-counter.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': minor
+---
+
+Add a dynamic selection counter to `Primer::Alpha::SelectPanel`. Pass `counter: true` (with optional `counter_arguments:`) to `with_show_button` to render a trailing `Counter` that updates live with the number of selected items, with no custom JavaScript required.

--- a/app/components/primer/alpha/select_panel.rb
+++ b/app/components/primer/alpha/select_panel.rb
@@ -297,6 +297,8 @@ module Primer
         :warning
       ].freeze
 
+      DEFAULT_COUNTER_ARGUMENTS = { hide_if_zero: true }.freeze
+
       # The URL to fetch search results from.
       #
       # @return [String]
@@ -506,8 +508,10 @@ module Primer
       # Adds a show button (i.e. a button) that will open the panel when clicked.
       #
       # @param icon [String] Name of <%= link_to_octicons %> to use instead of text. If an [icon](https://primer.style/octicons/usage-guidelines/) is provided, a <%= link_to_component(Primer::Beta::IconButton) %> will be rendered. Otherwise a <%= link_to_component(Primer::Beta::Button) %> will be rendered.
+      # @param counter [Boolean] When true, renders a dynamic selection counter on the show button that updates as items are selected.
+      # @param counter_arguments [Hash] System arguments forwarded to the trailing Counter (e.g. `scheme:`, `limit:`). The `data-target` wiring is applied automatically and cannot be overridden.
       # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Beta::Button) %>.
-      renders_one :show_button, lambda { |icon: nil, **system_arguments|
+      renders_one :show_button, lambda { |icon: nil, counter: false, counter_arguments: {}, **system_arguments|
         system_arguments[:id] = "#{@panel_id}-button"
 
         system_arguments[:aria] = merge_aria(
@@ -515,10 +519,16 @@ module Primer
           { aria: { controls: "#{@panel_id}-dialog", "haspopup": "dialog", "expanded": "false" } }
         )
 
+        if counter && icon.present? && should_raise_error?
+          raise ArgumentError, "`counter:` is not supported on icon show buttons"
+        end
+
         if icon.present?
           Primer::Beta::IconButton.new(icon: icon, **system_arguments)
         else
-          Primer::Beta::Button.new(**system_arguments)
+          button = Primer::Beta::Button.new(**system_arguments)
+          button.with_trailing_visual_counter(**dynamic_counter_arguments(counter_arguments)) if counter
+          button
         end
       }
 
@@ -544,6 +554,12 @@ module Primer
 
       def multi_select?
         select_variant == :multiple
+      end
+
+      def dynamic_counter_arguments(counter_arguments)
+        merged = DEFAULT_COUNTER_ARGUMENTS.merge(counter_arguments)
+        merged[:data] = merge_data(merged, { data: { targets: "select-panel.dynamicLabelCounts" } })
+        merged
       end
     end
   end

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -1,5 +1,5 @@
 import {getAnchoredPosition} from '@primer/behaviors'
-import {controller, target} from '@github/catalyst'
+import {controller, target, targets} from '@github/catalyst'
 import {IncludeFragmentElement} from '@github/include-fragment-element'
 import type {PrimerTextFieldElement} from '../../../lib/primer/forms/primer_text_field'
 import type {AnchorAlignment, AnchorSide} from '@primer/behaviors'
@@ -76,6 +76,7 @@ export class SelectPanelElement extends HTMLElement {
   @target bannerErrorElement: HTMLElement
   @target bodySpinner: HTMLElement
   @target liveRegion: LiveRegionElement
+  @targets dynamicLabelCounts: HTMLElement[]
 
   filterFn?: FilterFn
 
@@ -193,6 +194,7 @@ export class SelectPanelElement extends HTMLElement {
     this.addEventListener('remote-input-error', this, {signal})
     this.addEventListener('loadstart', this, {signal})
     this.#setDynamicLabel()
+    this.#setDynamicCounter()
     this.#updateInput()
     this.#softDisableItems()
     updateWhenVisible(this)
@@ -723,6 +725,7 @@ export class SelectPanelElement extends HTMLElement {
     }
 
     this.#hasLoadedData = true
+    this.#setDynamicCounter()
 
     if (!this.noResults) return
 
@@ -906,6 +909,7 @@ export class SelectPanelElement extends HTMLElement {
         }
 
         this.#setDynamicLabel()
+        this.#setDynamicCounter()
       }
     } else {
       // multi-select mode allows unchecking a checked item
@@ -918,6 +922,7 @@ export class SelectPanelElement extends HTMLElement {
       }
 
       this.#setDynamicLabel()
+      this.#setDynamicCounter()
     }
 
     this.#updateInput()
@@ -976,6 +981,16 @@ export class SelectPanelElement extends HTMLElement {
       }
     } else {
       invokerLabel.textContent = this.#originalLabel
+    }
+  }
+
+  #setDynamicCounter() {
+    const counters = this.dynamicLabelCounts
+    if (!counters.length) return
+    const count = this.#selectedItems.size
+    for (const counter of counters) {
+      counter.textContent = `${count}`
+      counter.hidden = count === 0
     }
   }
 

--- a/previews/primer/alpha/select_panel_preview.rb
+++ b/previews/primer/alpha/select_panel_preview.rb
@@ -165,6 +165,18 @@ module Primer
         })
       end
 
+      # @label With counter
+      #
+      # @param open_on_load toggle
+      # @param select_variant [Symbol] select [single, multiple]
+      def with_counter(open_on_load: false, select_variant: :multiple)
+        render_with_template(locals: {
+          open_on_load: open_on_load,
+          # .to_sym workaround for https://github.com/lookbook-hq/lookbook/issues/640
+          select_variant: select_variant.to_sym
+        })
+      end
+
       # @!endgroup
 
       # @label Footer buttons

--- a/previews/primer/alpha/select_panel_preview/with_counter.html.erb
+++ b/previews/primer/alpha/select_panel_preview/with_counter.html.erb
@@ -1,0 +1,21 @@
+<% subject_id = SecureRandom.hex %>
+
+<%= render(Primer::Alpha::SelectPanel.new(
+  data: { interaction_subject: subject_id },
+  id: "with_counter",
+  title: "Select items",
+  select_variant: select_variant,
+  fetch_strategy: :local,
+  open_on_load: open_on_load
+)) do |panel| %>
+  <% panel.with_show_button(counter: true) { "Choose items" } %>
+
+  <% panel.with_item(label: "Item 1", content_arguments: { data: { value: "item1" } }) %>
+  <% panel.with_item(label: "Item 2", content_arguments: { data: { value: "item2" } }) %>
+  <% panel.with_item(label: "Item 3", content_arguments: { data: { value: "item3" } }) %>
+  <% panel.with_item(label: "Item 4", content_arguments: { data: { value: "item4" } }) %>
+  <% panel.with_item(label: "Item 5", content_arguments: { data: { value: "item5" } }) %>
+  <% panel.with_item(label: "Item 6", content_arguments: { data: { value: "item6" } }) %>
+<% end %>
+
+<%= render partial: "primer/alpha/select_panel_preview/interaction_subject_js", locals: { subject_id: subject_id } %>

--- a/static/constants.json
+++ b/static/constants.json
@@ -714,6 +714,9 @@
       "warning"
     ],
     "DEFAULT_BANNER_SCHEME": "danger",
+    "DEFAULT_COUNTER_ARGUMENTS": {
+      "hide_if_zero": true
+    },
     "DEFAULT_FETCH_STRATEGY": "remote",
     "DEFAULT_PRELOAD": false,
     "DEFAULT_SELECT_VARIANT": "single",

--- a/static/info_arch.json
+++ b/static/info_arch.json
@@ -7982,6 +7982,18 @@
             "description": "Name of {{link_to_octicons}} to use instead of text. If an [icon](https://primer.style/octicons/usage-guidelines/) is provided, a {{#link_to_component}}Primer::Beta::IconButton{{/link_to_component}} will be rendered. Otherwise a {{#link_to_component}}Primer::Beta::Button{{/link_to_component}} will be rendered."
           },
           {
+            "name": "counter",
+            "type": "Boolean",
+            "default": "N/A",
+            "description": "When true, renders a dynamic selection counter on the show button that updates as items are selected."
+          },
+          {
+            "name": "counter_arguments",
+            "type": "Hash",
+            "default": "N/A",
+            "description": "System arguments forwarded to the trailing Counter (e.g. `scheme:`, `limit:`). The `data-target` wiring is applied automatically and cannot be overridden."
+          },
+          {
             "name": "system_arguments",
             "type": "Hash",
             "default": "N/A",
@@ -8268,6 +8280,19 @@
       {
         "preview_path": "primer/alpha/select_panel/with_dynamic_label_and_aria_prefix",
         "name": "with_dynamic_label_and_aria_prefix",
+        "snapshot": "false",
+        "skip_rules": {
+          "wont_fix": [
+            "region"
+          ],
+          "will_fix": [
+            "color-contrast"
+          ]
+        }
+      },
+      {
+        "preview_path": "primer/alpha/select_panel/with_counter",
+        "name": "with_counter",
         "snapshot": "false",
         "skip_rules": {
           "wont_fix": [

--- a/static/previews.json
+++ b/static/previews.json
@@ -3306,6 +3306,19 @@
         }
       },
       {
+        "preview_path": "primer/alpha/select_panel/with_counter",
+        "name": "with_counter",
+        "snapshot": "false",
+        "skip_rules": {
+          "wont_fix": [
+            "region"
+          ],
+          "will_fix": [
+            "color-contrast"
+          ]
+        }
+      },
+      {
         "preview_path": "primer/alpha/select_panel/footer_buttons",
         "name": "footer_buttons",
         "snapshot": "false",

--- a/test/components/alpha/select_panel_test.rb
+++ b/test/components/alpha/select_panel_test.rb
@@ -189,6 +189,41 @@ module Primer
 
          assert_selector(".Button--iconOnly")
       end
+
+      def test_counter_renders_wired_trailing_counter
+        render_inline(Primer::Alpha::SelectPanel.new(fetch_strategy: :local, select_variant: :multiple)) do |panel|
+          panel.with_show_button(counter: true) { "Assignees" }
+        end
+
+        assert_selector("span.Counter[data-targets~='select-panel.dynamicLabelCounts'][hidden]", visible: :all)
+      end
+
+      def test_counter_is_absent_by_default
+        render_inline(Primer::Alpha::SelectPanel.new(fetch_strategy: :local, select_variant: :multiple)) do |panel|
+          panel.with_show_button { "Assignees" }
+        end
+
+        refute_selector("span.Counter[data-targets~='select-panel.dynamicLabelCounts']", visible: :all)
+      end
+
+      def test_counter_arguments_merge_and_force_target
+        render_inline(Primer::Alpha::SelectPanel.new(fetch_strategy: :local, select_variant: :multiple)) do |panel|
+          panel.with_show_button(counter: true, counter_arguments: { scheme: :primary, data: { foo: "bar" } }) { "Assignees" }
+        end
+
+        # caller data preserved AND target forced in
+        assert_selector("span.Counter.Counter--primary[data-targets~='select-panel.dynamicLabelCounts'][data-foo='bar']", visible: :all)
+      end
+
+      def test_counter_with_icon_raises
+        error = assert_raises(ArgumentError) do
+          render_inline(Primer::Alpha::SelectPanel.new(fetch_strategy: :local, select_variant: :multiple)) do |panel|
+            panel.with_show_button(counter: true, icon: :gear) { "Assignees" }
+          end
+        end
+
+        assert_match(/counter/i, error.message)
+      end
     end
   end
 end

--- a/test/system/alpha/select_panel_test.rb
+++ b/test/system/alpha/select_panel_test.rb
@@ -762,6 +762,27 @@ module Alpha
       assert_selector "select-panel button[aria-controls]", exact_text: "Item: Item 2, Item 3"
     end
 
+    def test_counter_updates_on_selection
+      visit_preview(:with_counter, select_variant: :multiple)
+
+      click_on_invoker_button
+
+      # hidden at zero
+      assert_selector "select-panel .Counter[hidden]", visible: :all
+
+      click_on_second_item
+      click_on_third_item
+
+      # shows the tracked count, visible
+      assert_selector "select-panel .Counter", exact_text: "2"
+      refute_selector "select-panel .Counter[hidden]", visible: :all
+
+      # deselecting back to zero hides it again
+      click_on_second_item
+      click_on_third_item
+      assert_selector "select-panel .Counter[hidden]", visible: :all
+    end
+
     def test_dynamic_label_and_aria_prefix_for_single_select_variant
       visit_preview(:with_dynamic_label_and_aria_prefix, select_variant: :single)
 


### PR DESCRIPTION
Work package: [DREAM-738](https://community.openproject.org/wp/DREAM-738)

### What are you trying to accomplish?

Teaches `Primer::Alpha::SelectPanel` to show a self-updating count of selected items in its show button, with **no custom JavaScript** required downstream.

```erb
<% panel.with_show_button(counter: true) { "Assignees" } %>
```

Consumers (e.g. the OpenProject backlogs filter) previously had to hand-write a Stimulus controller just to keep a `Counter` in the show button in sync with the selection. That boilerplate now lives in the component.

- **Ruby:** `with_show_button` gains `counter:` (Boolean) + `counter_arguments:` (Hash). When `counter: true`, the button auto-renders a trailing `Counter` wired to a Catalyst target, defaulting to `hide_if_zero: true`. The target is forced via `merge_data` so a caller's `data:` cannot unwire it. `counter:` on an icon button raises `ArgumentError` (non-production).
- **TypeScript:** `SelectPanelElement` writes the live count (`selectedItems.length`, the tracked Map) into the counter on connect, on every item activation, and after fetch. Hides at zero.
- The legacy `dynamic_label` text path is untouched and may coexist with the counter.

### Integration

No production code changes required to adopt. Existing `SelectPanel` usages are unaffected; the counter is opt-in via `counter: true`. Downstream consumers can delete their bespoke counter-sync Stimulus controllers. `static/*.json` docs regenerate via CI on push.

#### List the issues that this change affects.

Closes [DREAM-738](https://community.openproject.org/wp/DREAM-738)

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

Additive, opt-in API in the `alpha` namespace. Legacy `dynamic_label` path untouched (regression-tested). Easily reverted.

### What approach did you choose and why?

The counter is rendered server-side via Primer `Button`'s native `trailing_visual_counter` slot and only **augmented** on the client — `SelectPanelElement` writes the count into a Catalyst target. This keeps with the library convention (server renders, client augments) rather than introducing client-side templating.

Count is read from the tracked `selectedItems` Map rather than a DOM query, so it stays correct in remote/filtered panels where selected items aren't currently in the DOM.

Alternatives discarded: a `<template>` + `{{count}}` placeholder syntax (collides with lit-html/Angular interpolation downstream) and web-component `<slot>`s (require shadow DOM; these elements are light-DOM).

### Anything you want to highlight for special attention from reviewers?

Primer `Button` renders a trailing counter **twice** — a visible `aria-hidden` copy and an `sr-only` copy (`app/components/primer/beta/button.html.erb`). The wiring therefore uses **plural** `data-targets` / `@targets dynamicLabelCounts` and updates both copies, which also keeps the screen-reader text in sync.

The count is keyed on each item's `data-value`; items need values to be counted (consistent with existing selection tracking).

### Accessibility

- [x] **No new axe scan violation** - This change does not introduce any new axe scan violations. The `sr-only` counter copy is kept in sync, so the selected count is announced to screen readers.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
