### PR TITLE
Teach BorderBox component a `list_arguments` param

### DIFF
--- a/.changeset/rare-coats-hide.md
+++ b/.changeset/rare-coats-hide.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Teach BorderBox component a list_arguments param

--- a/app/components/primer/beta/border_box.rb
+++ b/app/components/primer/beta/border_box.rb
@@ -71,8 +71,9 @@ module Primer
       }
 
       # @param padding [Symbol] <%= one_of(Primer::Beta::BorderBox::PADDING_MAPPINGS.keys) %>
+      # @param list_arguments [Hash] <%= link_to_system_arguments_docs %>
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(padding: DEFAULT_PADDING, **system_arguments)
+      def initialize(padding: DEFAULT_PADDING, list_arguments: {}, **system_arguments)
         list_id = system_arguments.delete(:list_id)
 
         @system_arguments = deny_tag_argument(**system_arguments)
@@ -84,9 +85,10 @@ module Primer
         )
 
         @system_arguments[:system_arguments_denylist] = { [:p, :pt, :pb, :pr, :pl] => PADDING_SUGGESTION }
-        @list_arguments = { tag: :ul }
+        @list_arguments = deny_tag_argument(**list_arguments)
+        @list_arguments[:tag] = :ul
         @list_arguments[:id] = list_id if list_id
-        @list_arguments[:classes] = "Box-list"
+        @list_arguments[:classes] = class_names("Box-list", @list_arguments[:classes])
       end
 
       def render?
@@ -98,9 +100,10 @@ module Primer
       def before_render
         return unless header
 
-        @list_arguments[:aria] = {
-          labelledby: header.id
-        }
+        @list_arguments[:aria] = merge_aria(
+          @list_arguments,
+          { aria: { labelledby: header.id } }
+        )
       end
     end
   end

--- a/app/components/primer/beta/border_box.rb
+++ b/app/components/primer/beta/border_box.rb
@@ -72,9 +72,11 @@ module Primer
 
       # @param padding [Symbol] <%= one_of(Primer::Beta::BorderBox::PADDING_MAPPINGS.keys) %>
       # @param list_arguments [Hash] <%= link_to_system_arguments_docs %>
+      # @param list_id [String] Deprecated. Use <code>list_arguments: { id: ... }</code> instead.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(padding: DEFAULT_PADDING, list_arguments: {}, **system_arguments)
         list_id = system_arguments.delete(:list_id)
+        deprecation_warn("The `list_id:` param is deprecated. Use `list_arguments: { id: ... }` instead. It will be removed in a future version.") if list_id
 
         @system_arguments = deny_tag_argument(**system_arguments)
         @system_arguments[:tag] = :div
@@ -87,7 +89,7 @@ module Primer
         @system_arguments[:system_arguments_denylist] = { [:p, :pt, :pb, :pr, :pl] => PADDING_SUGGESTION }
         @list_arguments = deny_tag_argument(**list_arguments)
         @list_arguments[:tag] = :ul
-        @list_arguments[:id] = list_id if list_id
+        @list_arguments[:id] ||= list_id if list_id
         @list_arguments[:classes] = class_names("Box-list", @list_arguments[:classes])
       end
 
@@ -104,6 +106,12 @@ module Primer
           @list_arguments,
           { aria: { labelledby: header.id } }
         )
+      end
+
+      def deprecation_warn(message)
+        return if Rails.env.production? || silence_deprecations?
+
+        ::Primer::ViewComponents.deprecation.warn(message)
       end
     end
   end

--- a/previews/primer/beta/border_box_preview.rb
+++ b/previews/primer/beta/border_box_preview.rb
@@ -6,11 +6,11 @@ module Primer
     class BorderBoxPreview < ViewComponent::Preview
       # @label Playground
       #
+      # @param list_id text
       # @param padding [Symbol] select [default, condensed, spacious]
       # @param scheme [Symbol] select [default, neutral, info, warning]
-      # @param list_id [String] text
-      def playground(padding: :default, scheme: :default, list_id: nil)
-        render(Primer::Beta::BorderBox.new(padding: padding, list_id: list_id)) do |component|
+      def playground(padding: :default, scheme: :default, list_id: "my-list")
+        render(Primer::Beta::BorderBox.new(padding: padding, list_arguments: { id: list_id })) do |component|
           component.with_header { "Header" }
           component.with_body { "Body" }
           component.with_row(scheme: scheme) { "#{scheme.to_s.capitalize} row one" }

--- a/static/arguments.json
+++ b/static/arguments.json
@@ -4251,6 +4251,18 @@
         "description": "One of `:condensed`, `:default`, or `:spacious`."
       },
       {
+        "name": "list_arguments",
+        "type": "Hash",
+        "default": "`{}`",
+        "description": "[System arguments](/system-arguments)"
+      },
+      {
+        "name": "list_id",
+        "type": "String",
+        "default": "N/A",
+        "description": "Deprecated. Use <code>list_arguments: { id: ... }</code> instead."
+      },
+      {
         "name": "system_arguments",
         "type": "Hash",
         "default": "N/A",

--- a/static/info_arch.json
+++ b/static/info_arch.json
@@ -13510,6 +13510,18 @@
         "description": "One of `:condensed`, `:default`, or `:spacious`."
       },
       {
+        "name": "list_arguments",
+        "type": "Hash",
+        "default": "`{}`",
+        "description": "{{link_to_system_arguments_docs}}"
+      },
+      {
+        "name": "list_id",
+        "type": "String",
+        "default": "N/A",
+        "description": "Deprecated. Use <code>list_arguments: { id: ... }</code> instead."
+      },
+      {
         "name": "system_arguments",
         "type": "Hash",
         "default": "N/A",

--- a/test/components/beta/border_box_test.rb
+++ b/test/components/beta/border_box_test.rb
@@ -33,6 +33,28 @@ class PrimerBetaBorderBoxTest < Minitest::Test
     assert_selector "ul[aria-labelledby='#{id}']"
   end
 
+  def test_renders_list_with_list_arguments
+    render_inline(Primer::Beta::BorderBox.new(list_arguments: { id: "fake-tbody", role: "rowgroup" })) do |component|
+      component.with_row { "Row" }
+    end
+
+    assert_selector "ul#fake-tbody"
+    assert_selector 'ul[role="rowgroup"]'
+  end
+
+  def test_labels_list_with_header_and_additional_label
+    render_inline(Primer::Beta::BorderBox.new(list_arguments: { aria: { labelledby: "my-footer" } })) do |component|
+      component.with_header { "Header" }
+      component.with_row { "Row" }
+      component.with_footer(id: "my-footer") { "Footer" }
+    end
+
+    header_id = page.find_css(".Box-header").first[:id]
+    footer_id = page.find_css(".Box-footer").first[:id]
+    assert_selector "ul[aria-labelledby*='#{header_id}']"
+    assert_selector "ul[aria-labelledby*='#{footer_id}']"
+  end
+
   def test_renders_body
     render_inline(Primer::Beta::BorderBox.new) do |component|
       component.with_body { "Body" }

--- a/test/components/beta/border_box_test.rb
+++ b/test/components/beta/border_box_test.rb
@@ -91,6 +91,24 @@ class PrimerBetaBorderBoxTest < Minitest::Test
     assert_selector("li.Box-row", count: 1)
   end
 
+  def test_warns_when_list_id_param_passed
+    with_silence_deprecations(false) do
+      ::Primer::ViewComponents.deprecation.expects(:warn).with("The `list_id:` param is deprecated. Use `list_arguments: { id: ... }` instead. It will be removed in a future version.").once
+      render_inline(Primer::Beta::BorderBox.new(list_id: "an-id")) do |component|
+        component.with_row { "First" }
+      end
+    end
+  end
+
+  def test_list_arguments_id_takes_precedence_over_deprecated_list_id
+    render_inline(Primer::Beta::BorderBox.new(list_id: "old-id", list_arguments: { id: "new-id" })) do |component|
+      component.with_row { "First" }
+    end
+
+    assert_selector("ul#new-id", count: 1)
+    assert_no_selector("ul#old-id")
+  end
+
   def test_renders_condensed
     render_inline(Primer::Beta::BorderBox.new(padding: :condensed)) do |component|
       component.with_body { "Body" }


### PR DESCRIPTION
🤖 Reopened from primer/view_components#3821

### What are you trying to accomplish?

Allows additional customization of the rendered `<ul>` by supporting system arguments.

**Our use case:**

We have a lightweight responsive table implementation based on the Border Box component. We are currently in the process of adding ARIA roles and metadata for better A11y support. Unfortunately, we can't apply additional attributes (e.g. `ul[role="rowgroup"]` without resorting to hackery.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration

No. It adds to existing API.

#### List the issues that this change affects.

Closes #3820

#### Risk Assessment


- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.


### Accessibility

- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [X] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [X] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
