### PR TITLE
Fix stylelint violations across component pcss

### DIFF
--- a/.changeset/polite-zebras-kiss.md
+++ b/.changeset/polite-zebras-kiss.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': patch
+---
+
+Fix stylelint violations across component pcss

--- a/app/components/primer/alpha/action_bar.pcss
+++ b/app/components/primer/alpha/action_bar.pcss
@@ -41,18 +41,15 @@
   bottom: 50%;
   float: left;
   height: calc(var(--control-medium-size) / 2);
-  /* stylelint-disable-next-line primer/spacing */
   margin: 0 var(--controlStack-medium-gap-condensed);
   border-left: var(--borderWidth-thin) solid var(--borderColor-muted);
   transform: translateY(-50%);
 }
 
 .ActionBar--small .ActionBar-divider {
-  /* stylelint-disable-next-line primer/spacing */
   margin: 0 var(--controlStack-small-gap-condensed);
 }
 
 .ActionBar--large .ActionBar-divider {
-  /* stylelint-disable-next-line primer/spacing */
   margin: 0 var(--controlStack-large-gap-condensed);
 }

--- a/app/components/primer/alpha/action_list.pcss
+++ b/app/components/primer/alpha/action_list.pcss
@@ -301,7 +301,6 @@ nav-list {
   width: 100%;
   /* stylelint-disable-next-line primer/spacing */
   padding-block: var(--actionListContent-paddingBlock);
-  /* stylelint-disable-next-line primer/spacing */
   padding-inline: var(--control-medium-paddingInline-condensed);
   color: var(--control-fgColor-rest);
   text-align: left;
@@ -319,7 +318,6 @@ nav-list {
 
   /* column-gap persists with empty grid-areas, margin applies only when children exist */
   & > :not(:last-child) {
-    /* stylelint-disable-next-line primer/spacing */
     margin-right: var(--control-medium-gap);
   }
 

--- a/app/components/primer/alpha/banner.pcss
+++ b/app/components/primer/alpha/banner.pcss
@@ -70,7 +70,6 @@
   /* is this used anywhere? could not find any use, but unsure */
   & .Banner-close {
     grid-area: close;
-    /* stylelint-disable-next-line primer/spacing */
     margin-left: var(--controlStack-medium-gap-condensed);
   }
 

--- a/app/components/primer/alpha/button_marketing.pcss
+++ b/app/components/primer/alpha/button_marketing.pcss
@@ -18,7 +18,7 @@
   vertical-align: middle;
   user-select: none;
   /* stylelint-disable-next-line primer/colors */
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.15) 0%, rgba(255, 255, 255, 0) 100%),
+  background: linear-gradient(180deg, rgb(255, 255, 255, 0.15) 0%, rgb(255, 255, 255, 0) 100%),
     var(--color-mktg-btn-bg) !important;
   border: 0;
 
@@ -37,7 +37,7 @@
     content: '';
 
     /* stylelint-disable-next-line primer/colors */
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.15) 0%, rgba(255, 255, 255, 0) 100%) !important;
+    background: linear-gradient(180deg, rgb(255, 255, 255, 0.15) 0%, rgb(255, 255, 255, 0) 100%) !important;
     border-radius: inherit;
     opacity: 0;
     transition: opacity 0.2s;
@@ -135,11 +135,11 @@
   color: #fff;
 
   /* stylelint-disable-next-line primer/colors */
-  background: linear-gradient(180deg, rgba(52, 183, 89, 0.15) 0%, rgba(46, 164, 79, 0) 100%), rgb(46, 164, 79) !important;
+  background: linear-gradient(180deg, rgb(52, 183, 89, 0.15) 0%, rgb(46, 164, 79, 0) 100%), rgb(46, 164, 79) !important;
 
   &::before {
     /* stylelint-disable-next-line primer/colors */
-    background: linear-gradient(180deg, rgba(52, 183, 89, 0.15) 0%, rgba(46, 164, 79, 0) 100%) !important;
+    background: linear-gradient(180deg, rgb(52, 183, 89, 0.15) 0%, rgb(46, 164, 79, 0) 100%) !important;
   }
 
   /* fallback :focus state */

--- a/app/components/primer/alpha/layout.pcss
+++ b/app/components/primer/alpha/layout.pcss
@@ -1,5 +1,7 @@
 /* Layout */
 
+/* stylelint-disable nesting-selector-no-missing-scoping-root -- inside @define-mixin the & resolves at the @mixin include site, so there is a scoping root */
+
 @define-mixin flow-as-row {
   grid-auto-flow: row;
   grid-template-columns: 1fr !important;
@@ -104,7 +106,7 @@
 
   grid-auto-flow: column;
   grid-template-columns: auto 0 minmax(0, calc(100% - var(--Layout-sidebar-width) - var(--Layout-gutter))); /* sidebar column, separator, main column */
-  grid-gap: var(--Layout-gutter);
+  gap: var(--Layout-gutter);
 
   & .Layout-sidebar {
     grid-column: 1;

--- a/app/components/primer/alpha/menu.pcss
+++ b/app/components/primer/alpha/menu.pcss
@@ -3,7 +3,6 @@
 /* A menu on the side of a page, defaults to left side. e.g. github.com/about */
 
 .menu {
-  /* stylelint-disable-next-line primer/spacing */
   margin-bottom: var(--stack-gap-normal);
   list-style: none;
   background-color: var(--bgColor-default);
@@ -14,7 +13,6 @@
 .menu-item {
   position: relative;
   display: block;
-  /* stylelint-disable-next-line primer/spacing */
   padding: var(--control-medium-paddingInline-condensed) var(--control-medium-paddingInline-spacious);
   color: var(--fgColor-default);
   border-bottom: var(--borderWidth-thin) solid var(--borderColor-default);
@@ -68,7 +66,6 @@
 
   & .octicon {
     width: 16px;
-    /* stylelint-disable-next-line primer/spacing */
     margin-right: var(--control-medium-gap);
     color: var(--fgColor-muted);
     text-align: center;
@@ -76,7 +73,6 @@
 
   & .Counter {
     float: right;
-    /* stylelint-disable-next-line primer/spacing */
     margin-left: var(--control-small-gap);
   }
 
@@ -87,7 +83,6 @@
 
   & .avatar {
     float: left;
-    /* stylelint-disable-next-line primer/spacing */
     margin-right: var(--control-small-gap);
   }
 
@@ -100,7 +95,6 @@
 
 .menu-heading {
   display: block;
-  /* stylelint-disable-next-line primer/spacing */
   padding: var(--control-medium-paddingInline-condensed) var(--control-medium-paddingInline-spacious);
   margin-top: 0;
   margin-bottom: 0;

--- a/app/components/primer/alpha/segmented_control.pcss
+++ b/app/components/primer/alpha/segmented_control.pcss
@@ -111,9 +111,7 @@
     &::before {
       position: absolute;
       inset: 0 0 0 -1px;
-      /* stylelint-disable-next-line primer/spacing */
       margin-top: var(--control-medium-paddingBlock);
-      /* stylelint-disable-next-line primer/spacing */
       margin-bottom: var(--control-medium-paddingBlock);
       content: '';
       border-left: var(--borderWidth-thin) solid var(--borderColor-default);

--- a/app/components/primer/alpha/tab_nav.pcss
+++ b/app/components/primer/alpha/tab_nav.pcss
@@ -3,7 +3,6 @@
 /* Outer wrapper */
 .tabnav {
   margin-top: 0;
-  /* stylelint-disable-next-line primer/spacing */
   margin-bottom: var(--stack-gap-normal);
   border-bottom: var(--borderWidth-thin) solid var(--borderColor-default);
 }
@@ -24,7 +23,6 @@
 .tabnav-tab {
   display: inline-block;
   flex-shrink: 0;
-  /* stylelint-disable-next-line primer/spacing */
   padding: var(--base-size-8) var(--control-medium-paddingInline-spacious);
   font-size: var(--text-body-size-medium);
   /* stylelint-disable-next-line primer/typography */
@@ -66,13 +64,11 @@
   }
 
   & .octicon {
-    /* stylelint-disable-next-line primer/spacing */
     margin-right: var(--control-small-gap);
     color: var(--fgColor-muted);
   }
 
   & .Counter {
-    /* stylelint-disable-next-line primer/spacing */
     margin-left: var(--control-small-gap);
     color: inherit;
   }
@@ -110,6 +106,5 @@ a.tabnav-extra:hover {
 ** the buttons to be floated or inline-block. */
 
 .tabnav-btn {
-  /* stylelint-disable-next-line primer/spacing */
   margin-left: var(--controlStack-medium-gap-condensed);
 }

--- a/app/components/primer/alpha/tree_view.pcss
+++ b/app/components/primer/alpha/tree_view.pcss
@@ -350,6 +350,7 @@
     /* stylelint-disable-next-line primer/spacing */
     margin: -1px;
     overflow: hidden;
+    /* stylelint-disable-next-line property-no-deprecated -- `clip` is the widely-supported visually-hidden idiom; kept for older-browser screen-reader support */
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border-width: 0;

--- a/app/components/primer/alpha/underline_nav.pcss
+++ b/app/components/primer/alpha/underline_nav.pcss
@@ -11,7 +11,6 @@
   justify-content: space-between;
 
   & .Counter {
-    /* stylelint-disable-next-line primer/spacing */
     margin-left: var(--control-medium-gap);
     color: var(--fgColor-default);
     background-color: var(--bgColor-neutral-muted, var(--color-neutral-muted));
@@ -33,7 +32,6 @@
 .UnderlineNav-item {
   position: relative;
   display: flex;
-  /* stylelint-disable-next-line primer/spacing */
   padding: 0 var(--control-medium-paddingInline-condensed);
   font-size: var(--text-body-size-medium);
   /* stylelint-disable-next-line primer/typography */
@@ -128,7 +126,6 @@
 
 .UnderlineNav-octicon {
   display: inline !important;
-  /* stylelint-disable-next-line primer/spacing */
   margin-right: var(--control-medium-gap);
   color: var(--fgColor-muted);
   fill: var(--fgColor-muted);

--- a/app/components/primer/beta/button.pcss
+++ b/app/components/primer/beta/button.pcss
@@ -1,6 +1,5 @@
 /* stylelint-disable selector-no-qualifying-type */
 /* stylelint-disable selector-max-type */
-/* stylelint-disable primer/spacing */
 
 /* CSS for Button  */
 

--- a/app/components/primer/beta/popover.pcss
+++ b/app/components/primer/beta/popover.pcss
@@ -17,7 +17,7 @@
   border-radius: var(--borderRadius-medium);
 
   /* adding !important to override utility classes used in dotcom */
-  /* stylelint-disable-next-line primer/box-shadow */
+  /* stylelint-disable-next-line primer/box-shadow -- intentional legacy shadow var with fallback, kept for dotcom compatibility */
   box-shadow: var(--shadow-floating-legacy, var(--color-shadow-large)) !important;
 
   /* Carets */

--- a/app/components/primer/beta/state.pcss
+++ b/app/components/primer/beta/state.pcss
@@ -5,7 +5,6 @@
 .state, /* TODO: Deprecate */
 .State {
   display: inline-block;
-  /* stylelint-disable-next-line primer/spacing */
   padding: var(--base-size-4) var(--control-medium-paddingInline-normal);
   font-size: var(--text-body-size-medium);
   font-weight: var(--base-text-weight-medium);

--- a/app/components/primer/beta/subhead.pcss
+++ b/app/components/primer/beta/subhead.pcss
@@ -2,9 +2,7 @@
 
 .Subhead {
   display: flex;
-  /* stylelint-disable-next-line primer/spacing */
   padding-bottom: var(--stack-padding-condensed);
-  /* stylelint-disable-next-line primer/spacing */
   margin-bottom: var(--stack-gap-normal);
   border-bottom: var(--borderWidth-thin) solid var(--borderColor-muted);
   flex-flow: row wrap;

--- a/app/components/primer/beta/timeline_item.pcss
+++ b/app/components/primer/beta/timeline_item.pcss
@@ -3,9 +3,7 @@
 .TimelineItem {
   position: relative;
   display: flex;
-  /* stylelint-disable-next-line primer/spacing */
   padding: var(--stack-padding-normal) 0;
-  /* stylelint-disable-next-line primer/spacing */
   margin-left: var(--stack-gap-normal);
 
   /* The Timeline */
@@ -34,7 +32,6 @@
   display: flex;
   width: var(--control-medium-size);
   height: var(--control-medium-size);
-  /* stylelint-disable-next-line primer/spacing */
   margin-right: var(--controlStack-medium-gap-condensed);
   /* stylelint-disable-next-line primer/spacing */
   margin-left: calc(var(--control-medium-size) / -2 + 1px);
@@ -75,7 +72,6 @@
   z-index: 1;
   height: var(--stack-gap-spacious);
   margin: 0;
-  /* stylelint-disable-next-line primer/spacing */
   margin-bottom: calc(var(--stack-gap-normal) * -1);
   /* stylelint-disable-next-line primer/spacing */
   margin-left: -56px;
@@ -90,7 +86,6 @@
 
   /* TimelineItem--condensed is often grouped. (commits) */
   &:last-child {
-    /* stylelint-disable-next-line primer/spacing */
     padding-bottom: var(--stack-gap-normal);
   }
 

--- a/app/components/primer/beta/truncate.pcss
+++ b/app/components/primer/beta/truncate.pcss
@@ -13,7 +13,6 @@
     white-space: nowrap;
 
     & + .Truncate-text {
-      /* stylelint-disable-next-line primer/spacing */
       margin-left: var(--control-small-gap);
     }
 

--- a/app/components/primer/open_project/border_box/collapsible_header.pcss
+++ b/app/components/primer/open_project/border_box/collapsible_header.pcss
@@ -1,5 +1,7 @@
 /* CSS for BorderBox::CollapsibleHeader  */
 
+/* stylelint-disable selector-nested-pattern -- component nests descendant class selectors (and `.X > &`) inside container queries, not &-prefixed selectors */
+
 .CollapsibleHeader {
   display: block;
   container-name: collapsible-header-container;
@@ -60,7 +62,7 @@
 
   .CollapsibleHeader-description {
     overflow: visible;
-    text-overflow: initial;
+    text-overflow: clip;
     white-space: normal;
     width: 100%;
   }

--- a/app/components/primer/open_project/border_grid.pcss
+++ b/app/components/primer/open_project/border_grid.pcss
@@ -3,26 +3,28 @@
 .BorderGrid {
     display: table;
     width: 100%;
-    margin-top: -16px;
-    margin-bottom: -16px;
+    margin-top: calc(-1 * var(--base-size-16));
+    margin-bottom: calc(-1 * var(--base-size-16));
     table-layout: fixed;
+    /* stylelint-disable-next-line primer/borders -- table border-collapse keyword, not a border size */
     border-collapse: collapse;
+    /* stylelint-disable-next-line primer/borders -- table border-style keyword, not a border size */
     border-style: hidden
 }
 
 .BorderGrid .BorderGrid-cell {
-    padding-top: 16px;
-    padding-bottom: 16px
+    padding-top: var(--base-size-16);
+    padding-bottom: var(--base-size-16)
 }
 
 .BorderGrid--spacious {
-    margin-top: -24px;
-    margin-bottom: -24px
+    margin-top: calc(-1 * var(--base-size-24));
+    margin-bottom: calc(-1 * var(--base-size-24))
 }
 
 .BorderGrid--spacious .BorderGrid-cell {
-    padding-top: 24px;
-    padding-bottom: 24px
+    padding-top: var(--base-size-24);
+    padding-bottom: var(--base-size-24)
 }
 
 .BorderGrid-row {
@@ -31,5 +33,5 @@
 
 .BorderGrid-cell {
     display: table-cell;
-    border: 1px solid var(--borderColor-muted)
+    border: var(--borderWidth-thin) solid var(--borderColor-muted)
 }

--- a/app/components/primer/open_project/filterable_tree_view.pcss
+++ b/app/components/primer/open_project/filterable_tree_view.pcss
@@ -30,12 +30,14 @@ filterable-tree-view {
 
 /* Highlight style for CSS Custom Highlight API */
 ::highlight(primer-filterable-tree-view-search-results) {
+  /* stylelint-disable-next-line primer/no-display-colors, primer/colors -- intentional yellow search-match highlight; no Primer semantic token exists for this */
   background-color: var(--display-yellow-scale-2);
 }
 
 /* Fallback: <mark> elements used when CSS Custom Highlight API is unavailable */
 /* stylelint-disable-next-line selector-max-type */
 filterable-tree-view mark {
+  /* stylelint-disable-next-line primer/no-display-colors, primer/colors -- intentional yellow search-match highlight; no Primer semantic token exists for this */
   background-color: var(--display-yellow-scale-2);
   color: inherit;
 }

--- a/app/components/primer/open_project/page_header.pcss
+++ b/app/components/primer/open_project/page_header.pcss
@@ -47,6 +47,7 @@
   flex: 1 auto;
 }
 
+/* stylelint-disable-next-line selector-max-type -- description holds rich text; links can only be targeted by the `a` type selector */
 .PageHeader-description--underlined-links a {
   /* Ensure the accessibility is met, given that the description is written in light grey */
   text-decoration: underline;
@@ -94,6 +95,7 @@
 /* Match the title bar and actions height with the toggle menu button for proper vertical alignment */
 .PageHeader--noBreadcrumb {
   & .PageHeader-titleBar {
+    /* stylelint-disable-next-line primer/typography -- control size var intentionally matches the toggle-menu button height for vertical alignment */
     line-height: var(--control-small-size);
   }
 

--- a/app/components/primer/open_project/pagination.pcss
+++ b/app/components/primer/open_project/pagination.pcss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-max-type -- pagination arrows are styled via `.Page[rel] > svg`; the svg icon can only be targeted by its type selector */
+
 .Page {
   min-width: var(--base-size-32);
   height: var(--base-size-32);
@@ -7,7 +9,7 @@
   white-space: nowrap;
   vertical-align: middle;
   cursor: pointer;
-  border-radius: var(--borderRadius-medium,.375rem);
+  border-radius: var(--borderRadius-medium);
   transition: background-color 0.2s cubic-bezier(0.3, 0, 0.5, 1);
   display: inline-flex;
   align-items: center;
@@ -62,6 +64,7 @@
 
 .Page[aria-current]:focus-visible {
   outline: 2px solid var(--bgColor-accent-emphasis);
+  /* stylelint-disable-next-line primer/box-shadow -- custom focus-ring built from Primer size/color primitives; no single Primer box-shadow token matches */
   box-shadow: inset 0 0 0 var(--base-size-2) var(--fgColor-onEmphasis);
 }
 

--- a/app/components/primer/open_project/side_panel/section.pcss
+++ b/app/components/primer/open_project/side_panel/section.pcss
@@ -4,11 +4,11 @@
   display: flex;
   align-items: center;
   height: 32px;
-  margin-bottom: 8px;
+  margin-bottom: var(--base-size-8);
 }
 
 .SidePanel-sectionCounter {
-  margin-left: 8px;
+  margin-left: var(--base-size-8);
 }
 
 .SidePanel-sectionAction {
@@ -22,6 +22,6 @@
   margin-top: 0;
 
   &:not(:last-child) {
-    margin-bottom: 16px;
+    margin-bottom: var(--base-size-16);
   }
 }


### PR DESCRIPTION
CI lints only changed `.pcss` files, so stylelint violations accumulated latent across the tree — surfacing one-by-one whenever an unrelated PR happens to touch a file (e.g. the v0.51.6 sync tripping `text_field.pcss`). This clears the whole `app/components/**` pcss tree so `stylelint --rd` passes with 0 errors.

## What changed

- **Removed 32 needless `stylelint-disable primer/spacing`** comments that no longer suppress anything (only the genuinely-needed 207 remain).
- **Auto-fixed** (`stylelint --fix`): `rgba`→`rgb` alias notation, and hardcoded spacing with an obvious token.
- **Real fixes:** negative margins → `calc(-1 * var(--base-size-*))` (`border_grid`), `text-overflow: initial` → `clip` (`collapsible_header`), dropped a redundant `border-radius` fallback (`pagination`).
- **Scoped disable for a rule false-positive:** `nesting-selector-no-missing-scoping-root` fires on the `&` inside `@define-mixin` blocks (`layout.pcss`), but there the `&` resolves at the `@mixin` include site — same reasoning the upstream config uses to disable this rule for CSS-in-JS.
- **Justified disables (each with a `--` reason)** for intentional fork deviations / rule false positives: the `.Page[rel] > svg` and description `a` type selectors, the container-query nested selectors, the legacy dotcom `box-shadow`, the yellow search-match highlight colors, and the visually-hidden `clip`.

## Notes

- No value/design changes beyond the token-equivalent ones above — CSS compiles and `static/*` is unaffected.
- Deliberately did not touch the design-token deviations (display colors, legacy shadows) as value changes — those are silenced with documented reasons for a designer to revisit if desired.
- Rebased onto `main` after the v0.51.6 upstream sync, which already carried the scoped `text_field.pcss` mixin disables, so that file drops out of this diff.
