### PR TITLE
Stabilise visual regression snapshot testing

### DIFF
--- a/.github/workflows/test-visual.yml
+++ b/.github/workflows/test-visual.yml
@@ -13,12 +13,21 @@ concurrency:
 
 env:
   FERRUM_PROCESS_TIMEOUT: 30
+  # Regeneration is opt-in: add the `regen-snapshots` label to a same-repo PR to
+  # rewrite and commit the baseline. Without it (or on fork PRs, which cannot be
+  # committed back to) the job only asserts against the committed snapshots and
+  # fails loudly on a real diff — it never commits. The same-repo guard here
+  # stops a labelled fork PR from running a regen that can never commit and
+  # skips the assert, giving a misleading green.
+  REGEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'regen-snapshots') }}
 
 jobs:
   visual:
     name: Visual and Semantic Markup Regressions
     if: ${{ github.event_name == 'pull_request' }}
-    timeout-minutes: 20
+    # 2-core ubuntu-latest: a full suite does not finish inside 20 min. Raised
+    # so a run completes instead of timing out and committing a partial baseline.
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -52,12 +61,20 @@ jobs:
           gem install overmind
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
-      - name: Run Playwright tests
-        id: playwright-run
-        continue-on-error: true
+      # Default path: compare against the committed baseline. No
+      # continue-on-error — a genuine over-threshold diff fails the job so drift
+      # surfaces loudly instead of being silently auto-committed.
+      - name: Run Playwright tests (assert)
+        id: playwright-assert
+        if: ${{ env.REGEN != 'true' }}
         run: ./script/run-playwright
+      # Opt-in path (regen-snapshots label): rewrite the baseline, then commit it.
+      - name: Run Playwright tests (regenerate)
+        id: playwright-regen
+        if: ${{ env.REGEN == 'true' }}
+        run: ./script/run-playwright --update-snapshots
       - name: Update to latest branch tip
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ env.REGEN == 'true' }}
         run: |
           set -e
           BRANCH="${GITHUB_EVENT_PULL_REQUEST_HEAD_REF}"
@@ -73,7 +90,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_EVENT_PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref }}
       - id: auto-commit
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ env.REGEN == 'true' }}
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: Generating component snapshots
@@ -81,7 +98,7 @@ jobs:
           push_options: --force-with-lease
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: "Changes detected"
-        if: steps.auto-commit.outputs.changes_detected == 'true'
+        if: ${{ env.REGEN == 'true' && steps.auto-commit.outputs.changes_detected == 'true' }}
         uses: phulsechinmay/rewritable-pr-comment@a1b041997fa84ec3e524ee9dee5ba0b5f4e73604 # v0.3.0
         with:
           message: |
@@ -92,11 +109,10 @@ jobs:
             [Review differences](https://github.com/opf/primer_view_components/pull/${{ github.event.number }}/files?file-filters%5B%5D=.png&file-filters%5B%5D=.yml&show-viewed-files=false)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_IDENTIFIER: "visual-comparison-diff"
+      # Uploaded on assert failures too, so authors can inspect the diff report.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: ${{ !cancelled() }}
         with:
           name: playwright-report
           path: .playwright/report/
           retention-days: 30
-      - name: Failure
-        if: ${{ steps.auto-commit.outputs.changes_detected == 'true' || steps.playwright-run.outcome == 'failure' }}
-        run: exit 1

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,13 @@ const config: PlaywrightTestConfig = {
   /* Run tests in files in parallel */
   fullyParallel: true,
   workers: process.env.CI ? 4 : undefined,
-  updateSnapshots: 'all',
+  // Assert against the committed baseline. 'none' means a missing baseline
+  // fails rather than being silently created, so new snapshots must be added
+  // via the regen path (the `regen-snapshots` PR label in test-visual.yml,
+  // which passes --update-snapshots and overrides this). Never rewrite
+  // unconditionally — 'all' rewrote every file every run and committed
+  // byte-churn.
+  updateSnapshots: 'none',
   use: {
     baseURL: 'http://127.0.0.1:4000',
     browserName: 'chromium',
@@ -30,7 +36,12 @@ const config: PlaywrightTestConfig = {
       animations: 'disabled',
     },
     toMatchSnapshot: {
+      // `threshold` sets per-pixel colour sensitivity; `maxDiffPixelRatio` sets
+      // how many pixels may differ before failing. Without a max-diff budget a
+      // single anti-aliased pixel of non-deterministic Chromium rasterisation
+      // fails the run. Tune if genuine small changes slip through.
       threshold: 0.1,
+      maxDiffPixelRatio: 0.01,
     },
   },
   /* Retry on CI only */

--- a/script/run-playwright
+++ b/script/run-playwright
@@ -1,4 +1,6 @@
 #! /bin/bash
 
 ./script/stop-existing-processes
-exec npx playwright test --workers 6
+# Worker count comes from playwright.config.ts (CI-aware); forward extra args
+# (e.g. --update-snapshots for the regen path in CI).
+exec npx playwright test "$@"


### PR DESCRIPTION
### What are you trying to accomplish?

Unrelated PRs (e.g. #500, "Bump primer octicons to 19.36.0") were going red for "visual changes" that were only a couple of bytes — `MODIFIED` PNGs with 0 additions / 0 deletions, i.e. no pixels visibly changed.

Root cause: `playwright.config.ts` set `updateSnapshots: 'all'`, so every run unconditionally **rewrote** all 1482 PNGs and 471 ARIA snapshots instead of comparing against the committed baseline (`threshold: 0.1` was dead code). The workflow then auto-committed any git-detected byte diff and hard-failed, so non-deterministic Chromium anti-aliasing produced spurious "Generating component snapshots" commits and red CI on PRs that changed no component behaviour.

This switches the model from *regenerate-and-commit-everything* to *assert-against-baseline, regenerate on intent*:

- Removes `updateSnapshots: 'all'` so runs compare against the committed baseline, and adds `maxDiffPixelRatio: 0.01` so trivial anti-aliasing noise passes instead of failing.
- Gates regeneration and the auto-commit behind a `regen-snapshots` PR label; normal runs only assert and fail loudly on a real diff, never committing.
- Forwards extra args through `script/run-playwright` so the regen path can pass `--update-snapshots`.
- Raises `timeout-minutes` from 20 to 45 and drops `continue-on-error` and the blanket `exit 1` step, so a partial or timed-out run fails instead of committing a partial baseline on the 2-core runners.

### Integration

CI-only. No production/runtime code changes; only the Playwright config, its runner script, and the `test-visual` workflow.

#### List the issues that this change affects.

https://community.openproject.org/wp/DREAM-773

Implements OpenProject DREAM-773 (WP#77709) "Stabilise visual regression testing in Primer View Component fork", the implementation of the decision in DREAM-772 (WP#77706). No corresponding GitHub issue.

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

CI infrastructure only, no shipped code, trivially reverted by restoring the three files.

### What approach did you choose and why?

Chose DREAM-772 Option 2 (keep visual regression + harden for 2-core) over stopping it (loses coverage on fork-only `open_project/*` components upstream cannot cover) or a fork-only surface (more filtering logic).

Assert mode fixes the churn at its source: sub-threshold render noise no longer rewrites files, so there is nothing spurious to commit. A genuine over-threshold diff now fails loudly rather than being silently auto-committed. Regeneration becomes an explicit, reviewable act via the `regen-snapshots` label, which also replaces the unreliable "regenerate locally" flow (macOS/Linux pixel diffs make local regen untrustworthy).

### Anything you want to highlight for special attention from reviewers?

- `maxDiffPixelRatio: 0.01` is a starting value — tune down if genuine small changes slip through, up if flakiness remains.
- **One-off clean baseline still required.** The current `main` baseline is stale (proven in DREAM-772 via `auto_complete` ARIA drift). After this merges, regenerate one clean full baseline on Linux by opening a PR with the `regen-snapshots` label — do not regenerate locally.
- A new `regen-snapshots` label must exist in the repo for the gated path to trigger.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
