### PR TITLE
[DREAM-776] Support partial selection mode for async TreeView

### DIFF
--- a/.changeset/floppy-symbols-punch.md
+++ b/.changeset/floppy-symbols-punch.md
@@ -1,0 +1,5 @@
+---
+'@openproject/primer-view-components': minor
+---
+
+Support async TreeViews for select variant :single and :multiple for select strategy :self

--- a/app/components/primer/alpha/tree_view/sub_tree_node.rb
+++ b/app/components/primer/alpha/tree_view/sub_tree_node.rb
@@ -185,8 +185,8 @@ module Primer
         def render_in(*args, **_kwargs, &block)
           super.tap do
             # check this _after_ rendering so @sub_tree's slots are defined
-            if @node.select_variant != :none && @sub_tree.defer?
-              raise ArgumentError, "TreeView does not currently support select variants for sub-trees loaded asynchronously."
+            if @node.select_variant == :multiple && @sub_tree.defer? && @select_strategy != :self
+              raise ArgumentError, "TreeView does not currently support the multiple select variant with #{@select_strategy.inspect} select strategy for sub-trees loaded asynchronously."
             end
           end
         end

--- a/app/controllers/primer/view_components/tree_view_items_controller.rb
+++ b/app/controllers/primer/view_components/tree_view_items_controller.rb
@@ -46,7 +46,8 @@ module Primer
 
         render(
           locals: {
-            action_menu_expanded: params[:action_menu_expanded] == "true"
+            action_menu_expanded: params[:action_menu_expanded] == "true",
+            select_variant: (params[:select_variant] || :none).to_sym
           }
         )
       end

--- a/app/views/primer/view_components/tree_view_items/async_alpha.html_fragment.erb
+++ b/app/views/primer/view_components/tree_view_items/async_alpha.html_fragment.erb
@@ -1,21 +1,21 @@
 <%= render(Primer::Alpha::TreeView::SubTree.new(path: ["primer"], node_variant: :div)) do |tree| %>
-  <% tree.with_sub_tree(label: "alpha") do |sub_tree| %>
+  <% tree.with_sub_tree(label: "alpha", select_variant: select_variant, select_strategy: :self) do |sub_tree| %>
     <% sub_tree.with_leading_visual_icons do |icons| %>
       <% icons.with_expanded_icon(icon: :"file-directory-open-fill", color: :accent) %>
       <% icons.with_collapsed_icon(icon: :"file-directory-fill", color: :accent) %>
     <% end %>
 
-    <% sub_tree.with_sub_tree(label: "action_menu", expanded: action_menu_expanded) do |sub_tree| %>
+    <% sub_tree.with_sub_tree(label: "action_menu", expanded: action_menu_expanded, select_variant: select_variant, select_strategy: :self) do |sub_tree| %>
       <% sub_tree.with_leading_visual_icons do |icons| %>
         <% icons.with_expanded_icon(icon: :"file-directory-open-fill", color: :accent) %>
         <% icons.with_collapsed_icon(icon: :"file-directory-fill", color: :accent) %>
       <% end %>
 
-      <% sub_tree.with_leaf(label: "group.rb") do |item| %>
+      <% sub_tree.with_leaf(label: "group.rb", select_variant: select_variant) do |item| %>
         <% item.with_leading_visual_icon(icon: :file) %>
       <% end %>
 
-      <% sub_tree.with_leaf(label: "heading.rb") do |item| %>
+      <% sub_tree.with_leaf(label: "heading.rb", select_variant: select_variant) do |item| %>
         <% item.with_leading_visual_icon(icon: :file) %>
       <% end %>
     <% end %>

--- a/previews/primer/alpha/tree_view_preview.rb
+++ b/previews/primer/alpha/tree_view_preview.rb
@@ -114,9 +114,11 @@ module Primer
       # @label Async alpha
       #
       # @param action_menu_expanded [Boolean] toggle
-      def async_alpha(action_menu_expanded: false)
+      # @param select_variant [Symbol] select [none, single, multiple]
+      def async_alpha(action_menu_expanded: false, select_variant: :none)
         render_with_template(locals: {
-          action_menu_expanded: coerce_bool(action_menu_expanded)
+          action_menu_expanded: coerce_bool(action_menu_expanded),
+          select_variant: select_variant.to_sym
         })
       end
 
@@ -194,6 +196,15 @@ module Primer
         render_with_template(locals: {
           select_variant: select_variant.to_sym,
           expanded: coerce_bool(expanded)
+        })
+      end
+
+      # @label Async form input
+      # @hidden
+      # @param select_variant [Symbol] select [single, multiple]
+      def async_form_input(select_variant: :single)
+        render_with_template(locals: {
+          select_variant: select_variant.to_sym
         })
       end
 

--- a/previews/primer/alpha/tree_view_preview/async_alpha.html.erb
+++ b/previews/primer/alpha/tree_view_preview/async_alpha.html.erb
@@ -1,12 +1,12 @@
 <div style="max-width: 400px">
   <%= render(Primer::Alpha::TreeView.new) do |tree_view| %>
-    <% tree_view.with_sub_tree(label: "primer") do |sub_tree| %>
+    <% tree_view.with_sub_tree(label: "primer", select_variant: select_variant, select_strategy: :self) do |sub_tree| %>
       <% sub_tree.with_leading_visual_icons do |icons| %>
         <% icons.with_expanded_icon(icon: :"file-directory-open-fill", color: :accent) %>
         <% icons.with_collapsed_icon(icon: :"file-directory-fill", color: :accent) %>
       <% end %>
 
-      <% sub_tree.with_loading_skeleton(src: primer_view_components.tree_view_items_async_alpha_path(action_menu_expanded: action_menu_expanded)) %>
+      <% sub_tree.with_loading_skeleton(src: primer_view_components.tree_view_items_async_alpha_path(action_menu_expanded: action_menu_expanded, select_variant: select_variant)) %>
     <% end %>
   <% end %>
 </div>

--- a/previews/primer/alpha/tree_view_preview/async_form_input.html.erb
+++ b/previews/primer/alpha/tree_view_preview/async_form_input.html.erb
@@ -1,0 +1,16 @@
+<%= form_with(url: primer_view_components.generic_form_submission_path(format: :json)) do |f| %>
+  <%= render(Primer::Alpha::Stack.new) do %>
+    <%= render(Primer::Alpha::TreeView.new(form_arguments: { builder: f, name: "folder_structure" })) do |tree| %>
+      <% tree.with_sub_tree(label: "primer", select_variant: select_variant, select_strategy: :self) do |sub_tree| %>
+        <% sub_tree.with_leading_visual_icons do |icons| %>
+          <% icons.with_expanded_icon(icon: :"file-directory-open-fill", color: :accent) %>
+          <% icons.with_collapsed_icon(icon: :"file-directory-fill", color: :accent) %>
+        <% end %>
+
+        <% sub_tree.with_loading_skeleton(src: primer_view_components.tree_view_items_async_alpha_path(select_variant: select_variant)) %>
+      <% end %>
+    <% end %>
+
+    <%= render(Primer::Alpha::SubmitButton.new(name: :submit, label: "Submit")) %>
+  <% end %>
+<% end %>

--- a/static/info_arch.json
+++ b/static/info_arch.json
@@ -10871,6 +10871,19 @@
         }
       },
       {
+        "preview_path": "primer/alpha/tree_view/async_form_input",
+        "name": "async_form_input",
+        "snapshot": "false",
+        "skip_rules": {
+          "wont_fix": [
+            "region"
+          ],
+          "will_fix": [
+            "color-contrast"
+          ]
+        }
+      },
+      {
         "preview_path": "primer/alpha/tree_view/doubled_path",
         "name": "doubled_path",
         "snapshot": "false",

--- a/static/previews.json
+++ b/static/previews.json
@@ -4933,6 +4933,19 @@
         }
       },
       {
+        "preview_path": "primer/alpha/tree_view/async_form_input",
+        "name": "async_form_input",
+        "snapshot": "false",
+        "skip_rules": {
+          "wont_fix": [
+            "region"
+          ],
+          "will_fix": [
+            "color-contrast"
+          ]
+        }
+      },
+      {
         "preview_path": "primer/alpha/tree_view/doubled_path",
         "name": "doubled_path",
         "snapshot": "false",

--- a/test/components/primer/alpha/tree_view_test.rb
+++ b/test/components/primer/alpha/tree_view_test.rb
@@ -159,16 +159,46 @@ module Primer
         assert_selector("[role=treeitem] .TreeViewItemVisual svg.octicon-sparkle-fill")
       end
 
-      def test_disallows_multi_select_for_async_sub_trees
-        error = assert_raises(ArgumentError) do
+      def test_disallows_multi_select_with_descendants_strategy_for_async_sub_trees
+        [:descendants, :mixed_descendants].each do |strategy|
+          error = assert_raises(ArgumentError) do
+            render_inline(Primer::Alpha::TreeView.new) do |tree|
+              tree.with_sub_tree(label: "src", select_variant: :multiple, select_strategy: strategy) do |sub_tree|
+                sub_tree.with_loading_spinner(src: "/foobar")
+              end
+            end
+          end
+
+          assert_equal error.message, "TreeView does not currently support the multiple select variant with #{strategy.inspect} select strategy for sub-trees loaded asynchronously."
+        end
+      end
+
+      def test_allows_valid_select_variant_and_strategy_combinations_for_async_sub_trees
+        # No assertions needed, the scenarios simply do not throw an error
+        # :none — always allowed regardless of strategy
+        Primer::Alpha::TreeView::SubTreeNode::SELECT_STRATEGIES.each do |strategy|
           render_inline(Primer::Alpha::TreeView.new) do |tree|
-            tree.with_sub_tree(label: "src", select_variant: :multiple) do |sub_tree|
+            tree.with_sub_tree(label: "src", select_variant: :none, select_strategy: strategy) do |sub_tree|
               sub_tree.with_loading_spinner(src: "/foobar")
             end
           end
         end
 
-        assert_equal error.message, "TreeView does not currently support select variants for sub-trees loaded asynchronously."
+        # :single — always allowed regardless of strategy
+        Primer::Alpha::TreeView::SubTreeNode::SELECT_STRATEGIES.each do |strategy|
+          render_inline(Primer::Alpha::TreeView.new) do |tree|
+            tree.with_sub_tree(label: "src", select_variant: :single, select_strategy: strategy) do |sub_tree|
+              sub_tree.with_loading_spinner(src: "/foobar")
+            end
+          end
+        end
+
+        # :multiple — only allowed with :self
+        render_inline(Primer::Alpha::TreeView.new) do |tree|
+          tree.with_sub_tree(label: "src", select_variant: :multiple, select_strategy: :self) do |sub_tree|
+            sub_tree.with_loading_spinner(src: "/foobar")
+          end
+        end
       end
 
       def test_supports_anchor_tags

--- a/test/system/alpha/tree_view_test.rb
+++ b/test/system/alpha/tree_view_test.rb
@@ -724,6 +724,27 @@ module Alpha
       nodes[0].assert_matches_selector("[aria-checked='false']")
     end
 
+    def test_single_select_works_after_async_loading
+      visit_preview(:async_alpha, select_variant: :single)
+
+      # Select "primer" first, then expand to trigger async load
+      activate_at_path("primer")
+      expand_at_path("primer")
+
+      # Wait for async content to appear but selection remains
+      assert_path("primer", "alpha")
+      assert_path_checked("primer")
+
+      # Expand down to the leaf nodes
+      expand_at_path("primer", "alpha")
+      expand_at_path("primer", "alpha", "action_menu")
+
+      # Select first leaf
+      activate_at_path("primer", "alpha", "action_menu", "group.rb")
+      assert_path_checked("primer", "alpha", "action_menu", "group.rb")
+      refute_path_checked("primer")
+    end
+
     def test_fires_event_before_checking
       visit_preview(:default, select_variant: :multiple)
 
@@ -983,6 +1004,61 @@ module Alpha
       response = JSON.parse(find("pre").text)
 
       assert_equal "{\"path\":[\"Docs & legal requirements\"],\"nodeId\":\"docs\",\"value\":\"4\"}", response.dig("form_params", "folder_structure", 0)
+    end
+
+    def test_single_select_form_submission_after_async_loading
+      visit_preview(:async_form_input, route_format: :json)
+
+      # Expand "primer" to trigger async load
+      activate_at_path("primer")
+      assert_path_checked("primer")
+      expand_at_path("primer")
+
+      # Wait for async content
+      assert_path("primer", "alpha")
+
+      # Expand down to leaf nodes
+      expand_at_path("primer", "alpha")
+      expand_at_path("primer", "alpha", "action_menu")
+
+      # Select a leaf — "primer" sub-tree should be deselected
+      activate_at_path("primer", "alpha", "action_menu", "group.rb")
+      assert_path_checked("primer", "alpha", "action_menu", "group.rb")
+      refute_path_checked("primer")
+
+      find("button[type=submit]").click
+
+      response = JSON.parse(find("pre").text)
+
+      assert_equal 1, response.dig("form_params", "folder_structure").size
+      assert_equal "{\"path\":[\"primer\",\"alpha\",\"action_menu\",\"group.rb\"]}", response.dig("form_params", "folder_structure", 0)
+    end
+
+    def test_multi_select_form_submission_after_async_loading
+      visit_preview(:async_form_input, select_variant: :multiple, route_format: :json)
+
+      check_at_path("primer")
+      expand_at_path("primer")
+
+      # Wait for async content
+      assert_path("primer", "alpha")
+
+      expand_at_path("primer", "alpha")
+      expand_at_path("primer", "alpha", "action_menu")
+
+      # Check two leaf nodes independently (select_strategy: :self means no cascade)
+      check_at_path("primer", "alpha", "action_menu", "group.rb")
+      check_at_path("primer", "alpha", "action_menu", "heading.rb")
+
+      find("button[type=submit]").click
+
+      response = JSON.parse(find("pre").text)
+      payloads = response.dig("form_params", "folder_structure")
+
+      assert_equal 3, payloads.size
+      assert_includes payloads, "{\"path\":[\"primer\"]}"
+      assert_includes payloads, "{\"path\":[\"primer\",\"alpha\",\"action_menu\",\"group.rb\"]}"
+      assert_includes payloads, "{\"path\":[\"primer\",\"alpha\",\"action_menu\",\"heading.rb\"]}"
     end
 
     def test_keyboard_focus_moves_to_parent_when_include_fragment_with_role_treeitem_is_collapsed


### PR DESCRIPTION




### What are you trying to accomplish?
Support async TreeViews for `select_variant:` `:single` and `:multiple` for `select_strategy :self`. Actually, the only thing preventing that was the guard we implemented. We forbid that originally because we did not know how to handle multi-select in combination with `select_strategy: :descendants`. This problem is still not ignored, but we allow other combinations.

#### List the issues that this change affects.
https://community.openproject.org/wp/DREAM-776


#### Risk Assessment
- [x] **Low risk** the change is small, highly observable, and easily rolled back.



